### PR TITLE
Fix worker crash lockout, PTY leaks, FTS orphans, and session exit race

### DIFF
--- a/db.js
+++ b/db.js
@@ -138,6 +138,9 @@ const stmts = {
   searchMapDeleteByType: db.prepare('DELETE FROM search_map WHERE type = ?'),
   searchInsertFts: db.prepare('INSERT OR REPLACE INTO search_fts(rowid, title, body) VALUES (?, ?, ?)'),
   searchInsertMap: db.prepare('INSERT OR REPLACE INTO search_map(id, type, folder) VALUES (?, ?, ?)'),
+  searchMapLookup: db.prepare('SELECT rowid FROM search_map WHERE id = ? AND type = ?'),
+  searchDeleteByRowid: db.prepare('DELETE FROM search_fts WHERE rowid = ?'),
+  searchMapDeleteByRowid: db.prepare('DELETE FROM search_map WHERE rowid = ?'),
   // Settings statements
   settingsGet: db.prepare('SELECT value FROM settings WHERE key = ?'),
   settingsUpsert: db.prepare(`
@@ -241,6 +244,16 @@ function setFolderMeta(folder, projectPath, indexMtimeMs) {
 
 const upsertSearchEntriesBatch = db.transaction((entries) => {
   for (const e of entries) {
+    // Delete any existing FTS row for this (id, type) pair before inserting.
+    // search_map uses INSERT OR REPLACE which deletes the old row and creates
+    // a new one with a new rowid, but the orphaned FTS5 row keyed to the old
+    // rowid would never be cleaned up — causing duplicate search results and
+    // unbounded FTS table growth.
+    const existing = stmts.searchMapLookup.get(e.id, e.type);
+    if (existing) {
+      stmts.searchDeleteByRowid.run(existing.rowid);
+      stmts.searchMapDeleteByRowid.run(existing.rowid);
+    }
     const result = stmts.searchInsertMap.run(e.id, e.type, e.folder || null);
     stmts.searchInsertFts.run(result.lastInsertRowid, e.title || '', e.body || '');
   }

--- a/main.js
+++ b/main.js
@@ -181,6 +181,15 @@ function createWindow() {
   });
 
   mainWindow.on('closed', () => {
+    // On macOS the app stays alive in the dock after the last window closes.
+    // Kill all running PTY processes so orphaned `claude` processes don't
+    // accumulate in the background with no way for the user to interact.
+    for (const [id, session] of activeSessions) {
+      if (!session.exited) {
+        try { session.pty.kill(); } catch {}
+      }
+      activeSessions.delete(id);
+    }
     mainWindow = null;
   });
 }
@@ -604,6 +613,19 @@ function populateCacheViaWorker() {
     console.error('Worker error:', err);
     sendStatus('Worker error: ' + err.message, 'error');
     populatingCache = false;
+  });
+
+  // If the worker exits abnormally (SIGSEGV, OOM, uncaught exception) without
+  // sending a message, neither the 'message' nor 'error' handler will fire.
+  // Reset the flag here to prevent a permanent lockout where the session list
+  // stays empty because populateCacheViaWorker() returns immediately.
+  worker.on('exit', (code) => {
+    if (populatingCache) {
+      populatingCache = false;
+      if (code !== 0) {
+        sendStatus('Scan worker exited unexpectedly', 'error');
+      }
+    }
   });
 }
 
@@ -1227,8 +1249,16 @@ ipcMain.handle('open-terminal', (_event, sessionId, projectPath, isNew, sessionO
     const realId = session.realSessionId || sessionId;
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('process-exited', realId, exitCode);
+      // If a fork/plan-accept transition re-keyed this session under realId
+      // but the PTY exited before transition detection ran, also notify the
+      // renderer for the original sessionId so it doesn't stay stuck as "Running".
+      if (realId !== sessionId && activeSessions.has(sessionId)) {
+        mainWindow.webContents.send('process-exited', sessionId, exitCode);
+      }
     }
     activeSessions.delete(realId);
+    // Clean up the original key too in case transition detection hasn't run yet
+    activeSessions.delete(sessionId);
   });
 
   if (sessionOptions?.forkFrom) {


### PR DESCRIPTION
## Summary

Fixes four bugs that can cause broken UI state, resource leaks, and data corruption:

- **Worker crash permanently empties session list:** If the `scan-projects` worker exits abnormally (SIGSEGV, OOM kill, uncaught exception), the `populatingCache` flag is never reset. Every subsequent call to `populateCacheViaWorker()` returns immediately, leaving users with a permanently empty session sidebar and no error message. Added a `worker.on('exit')` handler to reset the flag and surface an error status.

- **Orphaned PTY processes on macOS window close:** On macOS, closing the last window keeps the app alive in the dock, but all running PTY child processes continue with no way for the user to interact with them. They accumulate until the app is quit via Cmd+Q. Added cleanup in the `mainWindow.on('closed')` handler to kill all active PTY sessions.

- **FTS5 search index grows without bound:** `upsertSearchEntriesBatch` uses `INSERT OR REPLACE` on `search_map`, which silently deletes the old row and inserts a new one with a fresh `rowid`. The FTS5 row keyed to the old rowid is never cleaned up — causing duplicate search results and unbounded `search_fts` table growth over re-indexing cycles. Now looks up and deletes the stale FTS entry before inserting.

- **Session stuck showing "Running" after PTY exits:** When a PTY exits before the filesystem watcher's debounce fires to detect a fork/plan-accept transition, `onExit` only sends `process-exited` for the not-yet-transitioned ID. The original session key stays in `activeSessions` and the sidebar shows it as "Running" indefinitely. Now notifies the renderer for both the original and transitioned IDs, and cleans up both map keys.

## Changes

- `main.js`: Add `worker.on('exit')` handler for `populatingCache` reset, PTY cleanup on window close, and dual-key cleanup in `ptyProcess.onExit`
- `db.js`: Delete stale FTS5 rows before re-inserting in `upsertSearchEntriesBatch`; add `searchMapLookup`, `searchDeleteByRowid`, `searchMapDeleteByRowid` prepared statements

## Test plan

- [ ] Kill the scan worker mid-scan (e.g., `kill -9` the worker PID) and verify the session list re-populates on next trigger instead of staying empty
- [ ] On macOS, open sessions, close the window (don't quit), verify `claude` processes are killed via `ps aux | grep claude`
- [ ] Reopen the window from the dock and verify sessions can be started fresh
- [ ] Run a search, re-index a project, search again — verify no duplicate results appear
- [ ] Start a session, trigger a fork, and verify the original session shows correct exit status if the PTY exits during the transition window