### PR TITLE
Add configurable shell profiles for terminal sessions

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,10 +27,123 @@ const cleanPtyEnv = Object.fromEntries(
 // --- Cross-platform shell resolution ---
 const isWindows = process.platform === 'win32';
 
-function resolveShell() {
+// Discover available shell profiles on this system.
+// Returns an array of { id, name, path, args? } objects.
+function discoverShellProfiles() {
+  const profiles = [];
+
+  if (isWindows) {
+    const { execSync } = require('child_process');
+
+    // CMD
+    const comspec = process.env.COMSPEC || 'C:\\WINDOWS\\system32\\cmd.exe';
+    if (fs.existsSync(comspec)) {
+      profiles.push({ id: 'cmd', name: 'Command Prompt', path: comspec });
+    }
+
+    // PowerShell 7+ (pwsh)
+    const pwshCandidates = [
+      path.join(process.env.ProgramFiles || 'C:\\Program Files', 'PowerShell', '7', 'pwsh.exe'),
+      path.join(process.env.ProgramFiles || 'C:\\Program Files', 'PowerShell', '7-preview', 'pwsh.exe'),
+    ];
+    for (const p of pwshCandidates) {
+      if (fs.existsSync(p)) {
+        profiles.push({ id: 'pwsh', name: 'PowerShell 7', path: p });
+        break;
+      }
+    }
+
+    // Windows PowerShell 5.x
+    const ps5 = path.join(process.env.SystemRoot || 'C:\\WINDOWS', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+    if (fs.existsSync(ps5)) {
+      profiles.push({ id: 'powershell', name: 'Windows PowerShell', path: ps5 });
+    }
+
+    // Git Bash
+    const gitBashCandidates = [
+      path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'),
+      path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'),
+      path.join(process.env.LOCALAPPDATA || '', 'Programs', 'Git', 'bin', 'bash.exe'),
+    ];
+    for (const p of gitBashCandidates) {
+      if (p && fs.existsSync(p)) {
+        profiles.push({ id: 'git-bash', name: 'Git Bash', path: p });
+        break;
+      }
+    }
+
+    // MSYS2
+    if (fs.existsSync('C:\\msys64\\usr\\bin\\bash.exe')) {
+      profiles.push({ id: 'msys2', name: 'MSYS2', path: 'C:\\msys64\\usr\\bin\\bash.exe' });
+    }
+
+    // WSL distributions
+    try {
+      const raw = execSync('wsl.exe --list --quiet', { timeout: 5000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+      const distros = raw.replace(/\0/g, '').split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+      for (const distro of distros) {
+        profiles.push({ id: 'wsl:' + distro, name: 'WSL — ' + distro, path: 'wsl.exe', args: ['-d', distro] });
+      }
+    } catch {}
+  } else {
+    // macOS / Linux: read /etc/shells for the canonical list
+    const seen = new Set();
+    const shellNames = {
+      'zsh': 'Zsh', 'bash': 'Bash', 'sh': 'POSIX Shell',
+      'fish': 'Fish', 'nu': 'Nushell', 'pwsh': 'PowerShell',
+      'dash': 'Dash', 'ksh': 'Korn Shell', 'tcsh': 'tcsh', 'csh': 'C Shell',
+    };
+    try {
+      const lines = fs.readFileSync('/etc/shells', 'utf8').split('\n')
+        .map(l => l.trim())
+        .filter(l => l && !l.startsWith('#'));
+      for (const shellPath of lines) {
+        if (!fs.existsSync(shellPath)) continue;
+        const base = path.basename(shellPath);
+        // Deduplicate by basename (e.g. /bin/bash and /usr/bin/bash)
+        if (seen.has(base)) continue;
+        seen.add(base);
+        const name = shellNames[base] || base;
+        profiles.push({ id: base, name, path: shellPath });
+      }
+    } catch {
+      // Fallback if /etc/shells is unreadable
+      for (const [id, name, p] of [
+        ['zsh', 'Zsh', '/bin/zsh'],
+        ['bash', 'Bash', '/bin/bash'],
+        ['sh', 'POSIX Shell', '/bin/sh'],
+      ]) {
+        if (fs.existsSync(p)) {
+          profiles.push({ id, name, path: p });
+        }
+      }
+    }
+  }
+
+  return profiles;
+}
+
+// Cache profiles (discovered once on startup, refreshed via IPC if needed)
+let _shellProfiles = null;
+function getShellProfiles() {
+  if (!_shellProfiles) _shellProfiles = discoverShellProfiles();
+  return _shellProfiles;
+}
+
+function resolveShell(profileId) {
+  // If a profile is selected, use it
+  if (profileId && profileId !== 'auto') {
+    const profiles = getShellProfiles();
+    const profile = profiles.find(p => p.id === profileId);
+    if (profile && (profile.path === 'wsl.exe' || fs.existsSync(profile.path))) {
+      return profile;
+    }
+  }
+
+  // Auto: original detection logic
   // 1. Respect explicit SHELL env (set by Git Bash, MSYS2, WSL, etc.)
   if (process.env.SHELL && fs.existsSync(process.env.SHELL)) {
-    return process.env.SHELL;
+    return { id: 'auto', name: 'Auto', path: process.env.SHELL };
   }
 
   if (isWindows) {
@@ -42,36 +155,40 @@ function resolveShell() {
       'C:\\msys64\\usr\\bin\\bash.exe',
     ];
     for (const c of candidates) {
-      if (c && fs.existsSync(c)) return c;
+      if (c && fs.existsSync(c)) return { id: 'auto', name: 'Auto', path: c };
     }
     // 3. Fall back to PowerShell / cmd
-    return process.env.COMSPEC || 'powershell.exe';
+    return { id: 'auto', name: 'Auto', path: process.env.COMSPEC || 'powershell.exe' };
   }
 
   // Unix fallback chain
   for (const s of ['/bin/zsh', '/bin/bash', '/bin/sh']) {
-    if (fs.existsSync(s)) return s;
+    if (fs.existsSync(s)) return { id: 'auto', name: 'Auto', path: s };
   }
-  return '/bin/sh';
+  return { id: 'auto', name: 'Auto', path: '/bin/sh' };
 }
 
 // Returns spawn args appropriate for the resolved shell
-function shellArgs(shell, cmd) {
-  const base = path.basename(shell).toLowerCase();
+function shellArgs(shellPath, cmd, extraArgs) {
+  const base = path.basename(shellPath).toLowerCase();
   const isBashLike = base.includes('bash') || base.includes('zsh') || base === 'sh';
 
+  // WSL: pass command via -- to the distribution shell
+  if (base === 'wsl.exe' || base === 'wsl') {
+    if (cmd) return [...(extraArgs || []), '--', 'bash', '-l', '-i', '-c', cmd];
+    return [...(extraArgs || []), '--', 'bash', '-l', '-i'];
+  }
+
   if (cmd) {
-    // Execute a command then exit
     if (isBashLike) return ['-l', '-i', '-c', cmd];
     if (base.includes('powershell') || base.includes('pwsh')) return ['-NoLogo', '-Command', cmd];
-    // cmd.exe
     return ['/C', cmd];
   }
-  // Interactive shell
   if (isBashLike) return ['-l', '-i'];
   if (base.includes('powershell') || base.includes('pwsh')) return ['-NoLogo', '-NoExit'];
   return [];
 }
+
 
 // --- Auto-updater (only in packaged builds) ---
 let autoUpdater = null;
@@ -846,7 +963,12 @@ ipcMain.handle('get-stats', () => {
 
 // --- IPC: refresh-stats (run /stats + /usage via PTY) ---
 ipcMain.handle('refresh-stats', async () => {
-  const shell = resolveShell();
+  // For stats, use the configured shell profile
+  const globalSettings = getSetting('global') || {};
+  const statsProfileId = globalSettings.shellProfile || SETTING_DEFAULTS.shellProfile;
+  const statsShellProfile = resolveShell(statsProfileId);
+  const statsShell = statsShellProfile.path;
+  const statsShellExtraArgs = statsShellProfile.args || [];
   const ptyEnv = {
     ...cleanPtyEnv,
     TERM: 'xterm-256color',
@@ -875,7 +997,7 @@ ipcMain.handle('refresh-stats', async () => {
       };
 
       const claudeCmd = `claude ${args}`;
-      const p = pty.spawn(shell, shellArgs(shell, claudeCmd), {
+      const p = pty.spawn(statsShell, shellArgs(statsShell, claudeCmd, statsShellExtraArgs), {
         name: 'xterm-256color',
         cols: 120,
         rows: 40,
@@ -1175,7 +1297,13 @@ const SETTING_DEFAULTS = {
   sidebarWidth: 340,
   terminalTheme: 'switchboard',
   mcpEmulation: false,
+  shellProfile: 'auto',
 };
+
+ipcMain.handle('get-shell-profiles', () => {
+  _shellProfiles = null; // refresh on each request
+  return getShellProfiles();
+});
 
 ipcMain.handle('get-effective-settings', (_event, projectPath) => {
   const global = getSetting('global') || {};
@@ -1294,7 +1422,19 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
     return { ok: false, error: `project directory no longer exists: ${projectPath}` };
   }
 
-  const shell = resolveShell();
+  // Resolve shell profile from effective settings
+  const effectiveSettings = (() => {
+    const global = getSetting('global') || {};
+    const project = projectPath ? (getSetting('project:' + projectPath) || {}) : {};
+    let profileId = SETTING_DEFAULTS.shellProfile;
+    if (global.shellProfile !== undefined && global.shellProfile !== null) profileId = global.shellProfile;
+    if (project.shellProfile !== undefined && project.shellProfile !== null) profileId = project.shellProfile;
+    return profileId;
+  })();
+  const shellProfile = resolveShell(effectiveSettings);
+  const shell = shellProfile.path;
+  const shellExtraArgs = shellProfile.args || [];
+  log.info(`[shell] profile=${shellProfile.id} shell=${shell} args=${JSON.stringify(shellExtraArgs)}`);
   const isPlainTerminal = sessionOptions?.type === 'terminal';
 
   let knownJsonlFiles = new Set();
@@ -1334,7 +1474,7 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
       // Plain terminal: interactive login shell, no claude command
       // Inject a shell function to override `claude` with a helpful message
       const claudeShim = 'claude() { echo "\\033[33mTo start a Claude session, use the + button in the sidebar.\\033[0m"; return 1; }; export -f claude 2>/dev/null;';
-      ptyProcess = pty.spawn(shell, shellArgs(shell), {
+      ptyProcess = pty.spawn(shell, shellArgs(shell, undefined, shellExtraArgs), {
         name: 'xterm-256color',
         cols: 120,
         rows: 30,
@@ -1414,7 +1554,7 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
         ptyEnv.CLAUDE_CODE_SSE_PORT = String(mcpServer.port);
       }
 
-      ptyProcess = pty.spawn(shell, shellArgs(shell, claudeCmd), {
+      ptyProcess = pty.spawn(shell, shellArgs(shell, claudeCmd, shellExtraArgs), {
         name: 'xterm-256color',
         cols: 120,
         rows: 30,

--- a/preload.js
+++ b/preload.js
@@ -26,6 +26,7 @@ contextBridge.exposeInMainWorld('api', {
   setSetting: (key, value) => ipcRenderer.invoke('set-setting', key, value),
   deleteSetting: (key) => ipcRenderer.invoke('delete-setting', key),
   getEffectiveSettings: (projectPath) => ipcRenderer.invoke('get-effective-settings', projectPath),
+  getShellProfiles: () => ipcRenderer.invoke('get-shell-profiles'),
 
   browseFolder: () => ipcRenderer.invoke('browse-folder'),
   addProject: (projectPath) => ipcRenderer.invoke('add-project', projectPath),

--- a/public/app.js
+++ b/public/app.js
@@ -11,6 +11,7 @@ const terminalHeader = document.getElementById('terminal-header');
 const terminalHeaderName = document.getElementById('terminal-header-name');
 const terminalHeaderId = document.getElementById('terminal-header-id');
 const terminalHeaderStatus = document.getElementById('terminal-header-status');
+const terminalHeaderShell = document.getElementById('terminal-header-shell');
 const terminalStopBtn = document.getElementById('terminal-stop-btn');
 const terminalRestartBtn = document.getElementById('terminal-restart-btn');
 const runningToggle = document.getElementById('running-toggle');
@@ -1513,12 +1514,28 @@ function openNewSession(project) {
   return launchNewSession(project);
 }
 
-function showTerminalHeader(session) {
+async function showTerminalHeader(session) {
   const displayName = cleanDisplayName(session.name || session.summary);
   terminalHeaderName.textContent = displayName;
   terminalHeaderId.textContent = session.sessionId;
   terminalHeader.style.display = '';
   updateTerminalHeader();
+
+  // Show active shell profile
+  try {
+    const effective = await window.api.getEffectiveSettings(session.projectPath);
+    const profileId = effective.shellProfile || 'auto';
+    if (profileId === 'auto') {
+      terminalHeaderShell.style.display = 'none';
+    } else {
+      const profiles = await window.api.getShellProfiles();
+      const profile = profiles.find(p => p.id === profileId);
+      terminalHeaderShell.textContent = profile ? profile.name : profileId;
+      terminalHeaderShell.style.display = '';
+    }
+  } catch {
+    terminalHeaderShell.style.display = 'none';
+  }
 }
 
 async function openSession(session) {
@@ -3024,6 +3041,11 @@ async function openSettingsViewer(scope, projectPath) {
   const maxAgeValue = fieldValue('sessionMaxAgeDays', 3);
   const themeValue = fieldValue('terminalTheme', 'switchboard');
   const mcpEmulationValue = fieldValue('mcpEmulation', true);
+  const shellProfileValue = fieldValue('shellProfile', 'auto');
+
+  // Discover available shell profiles
+  let shellProfiles = [];
+  try { shellProfiles = await window.api.getShellProfiles(); } catch {};
 
   settingsViewerBody.innerHTML = `
     <div class="settings-form">
@@ -3115,6 +3137,20 @@ async function openSettingsViewer(scope, projectPath) {
 
         <div class="settings-field">
           <div class="settings-field-header">
+            <span class="settings-label">Shell Profile</span>
+            ${useGlobalCheckbox('shellProfile')}
+          </div>
+          <div class="settings-hint">Shell used for terminal and Claude sessions. Changes take effect for new sessions only.</div>
+          <select class="settings-select" id="sv-shell-profile" ${fieldDisabled('shellProfile')}>
+            <option value="auto" ${shellProfileValue === 'auto' ? 'selected' : ''}>Auto (detect)</option>
+            ${shellProfiles.map(p =>
+              `<option value="${escapeHtml(p.id)}" ${shellProfileValue === p.id ? 'selected' : ''}>${escapeHtml(p.name)}</option>`
+            ).join('')}
+          </select>
+        </div>
+
+        <div class="settings-field">
+          <div class="settings-field-header">
             <span class="settings-label">Max Visible Sessions</span>
             ${useGlobalCheckbox('visibleSessionCount')}
           </div>
@@ -3170,6 +3206,7 @@ async function openSettingsViewer(scope, projectPath) {
         preLaunchCmd: 'sv-pre-launch',
         addDirs: 'sv-add-dirs',
         visibleSessionCount: 'sv-visible-count',
+        shellProfile: 'sv-shell-profile',
       };
       const input = settingsViewerBody.querySelector('#' + fieldMap[field]);
       if (input) input.disabled = cb.checked;
@@ -3193,6 +3230,7 @@ async function openSettingsViewer(scope, projectPath) {
             preLaunchCmd: () => settingsViewerBody.querySelector('#sv-pre-launch').value.trim(),
             addDirs: () => settingsViewerBody.querySelector('#sv-add-dirs').value.trim(),
             visibleSessionCount: () => parseInt(settingsViewerBody.querySelector('#sv-visible-count').value) || 10,
+            shellProfile: () => settingsViewerBody.querySelector('#sv-shell-profile').value || 'auto',
           };
           if (fieldMap[field]) settings[field] = fieldMap[field]();
         }
@@ -3208,6 +3246,7 @@ async function openSettingsViewer(scope, projectPath) {
       settings.sessionMaxAgeDays = parseInt(settingsViewerBody.querySelector('#sv-max-age').value) || 3;
       settings.terminalTheme = settingsViewerBody.querySelector('#sv-terminal-theme').value || 'switchboard';
       settings.mcpEmulation = settingsViewerBody.querySelector('#sv-mcp-emulation').checked;
+      settings.shellProfile = settingsViewerBody.querySelector('#sv-shell-profile').value || 'auto';
     }
 
     // Preserve windowBounds and sidebarWidth if they exist

--- a/public/index.html
+++ b/public/index.html
@@ -97,6 +97,7 @@
           <span id="terminal-header-name"></span>
           <span id="terminal-header-pty-title" style="display:none;"></span>
           <span id="terminal-header-id"></span>
+          <span id="terminal-header-shell" style="display:none;"></span>
         </div>
         <div id="terminal-header-controls">
           <span id="terminal-header-status"></span>

--- a/public/style.css
+++ b/public/style.css
@@ -907,6 +907,16 @@ body { display: flex; flex-direction: column; }
   font-family: 'SF Mono', 'Fira Code', Menlo, monospace;
 }
 
+#terminal-header-shell {
+  font-size: 10px;
+  color: #8a8aa0;
+  background: rgba(255,255,255,0.06);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: 'SF Mono', 'Fira Code', Menlo, monospace;
+  white-space: nowrap;
+}
+
 #terminal-header-controls {
   display: flex;
   align-items: center;

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -8,6 +8,14 @@ try {
   execSync('npx electron-builder install-app-deps', { stdio: 'inherit' });
 } catch (err) {
   console.error('electron-builder install-app-deps failed:', err.message);
+  // Fallback: rebuild only better-sqlite3 for Electron (node-pty uses prebuilds)
+  console.log('Attempting fallback: rebuilding better-sqlite3 for Electron...');
+  try {
+    execSync('npx @electron/rebuild -f -m . -o better-sqlite3', { stdio: 'inherit' });
+    console.log('Fallback rebuild succeeded.');
+  } catch (err2) {
+    console.error('Fallback rebuild also failed:', err2.message);
+  }
 }
 
 // macOS/Linux: ad-hoc codesign native modules & fix node-pty permissions


### PR DESCRIPTION
## Summary

- **Shell profile discovery** — automatically detects available shells on the system:
  - **Windows**: Command Prompt, PowerShell 7, Windows PowerShell 5, Git Bash, MSYS2, and all installed WSL distributions
  - **macOS/Linux**: reads `/etc/shells` for all registered shells (zsh, bash, fish, nushell, etc.)
- **Settings UI** — adds a "Shell Profile" dropdown to both Global and per-project Settings, with an "Auto (detect)" default that preserves the existing behavior
- **Per-project override** — projects can override the global shell profile via the "Use global default" checkbox pattern already used by other settings
- **Session header badge** — shows the active shell profile name in the terminal header when a non-auto profile is selected
- **WSL support** — WSL distributions are spawned via `wsl.exe -d <distro>` with proper argument passthrough for both interactive and command execution modes

## Changes

| File | What changed |
|------|-------------|
| `main.js` | Added `discoverShellProfiles()`, updated `resolveShell()` to accept profile ID, added WSL support to `shellArgs()`, added `shellProfile` to `SETTING_DEFAULTS`, added `get-shell-profiles` IPC handler, updated `open-terminal` and `refresh-stats` to use effective shell profile |
| `preload.js` | Exposed `getShellProfiles` IPC binding |
| `public/app.js` | Shell profile dropdown in settings UI (global + per-project), shell badge in terminal header |
| `public/index.html` | Added `#terminal-header-shell` element |
| `public/style.css` | Styling for shell profile badge |
| `scripts/postinstall.js` | Added fallback rebuild path for `better-sqlite3` when `electron-builder install-app-deps` fails |

## Design decisions

- **`resolveShell()` returns an object** (`{ id, name, path, args? }`) instead of a plain string, to carry profile metadata and WSL extra args through the spawn pipeline
- **Discovery is refreshed on each settings open** (via IPC) so newly installed shells appear without restarting the app
- **Changes only affect new sessions** — running sessions continue using whatever shell they were started with
- **"Auto" hides the badge** to avoid visual clutter when no explicit choice has been made

## Test plan

- [ ] Open Global Settings → verify Shell Profile dropdown lists detected shells
- [ ] Select a non-auto profile (e.g. PowerShell 7) → start a new session → verify it launches in the correct shell
- [ ] Set a per-project override → verify it takes precedence over global
- [ ] Check "Use global default" on a project → verify it falls back to global
- [ ] Start a WSL session (if WSL installed) → verify it opens in the correct distro
- [ ] Verify existing/resumed sessions are unaffected by profile changes
- [ ] Verify the shell badge appears in the session header for non-auto profiles
- [ ] Test on macOS/Linux if possible — verify `/etc/shells` discovery works

🤖 Generated with [Claude Code](https://claude.com/claude-code)