### PR TITLE
fix: send Space keydown directly to PTY for reliable key-repeat

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -268,6 +268,21 @@ function setupTerminalKeyBindings(terminal, container, getSessionId, { onFind } 
       }
     }
 
+    // Space → send directly on keydown (including key-repeat) to ensure reliable
+    // delivery to the PTY. xterm.js's evaluateKeyboardEvent does not handle plain
+    // Space in keydown (keyCode 32 < 48 threshold) and instead relies on the
+    // deprecated 'keypress' event, which Electron/Chromium may not fire reliably
+    // for key-repeat events. This fixes Claude Code's "Hold Space to record"
+    // push-to-talk voice feature, which depends on rapid key-repeat characters
+    // arriving at stdin to detect a held key.
+    if (e.key === ' ' && !e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey) {
+      if (e.type === 'keydown') {
+        e.preventDefault();
+        window.api.sendInput(getSessionId(), ' ');
+      }
+      return false;
+    }
+
     return true;
   });
 


### PR DESCRIPTION
## Summary

Fixes #22 — Space key hold (for Claude Code's push-to-talk voice recording) doesn't work inside Switchboard.

### Root cause

xterm.js's `evaluateKeyboardEvent` (`Keyboard.ts:357`) has this condition for single-character keys:

```js
ev.keyCode >= 48 && ev.key.length === 1
```

Space has `keyCode = 32`, which is **less than 48**, so `result.key` remains `undefined`. This means `_keyDown` never calls `triggerDataEvent` for Space — it returns early without sending data.

Instead, Space data relies entirely on the **deprecated `keypress` event** (via `_keyPress`). In Electron/Chromium, `keypress` may not fire reliably for key-repeat events, which breaks Claude Code's hold detection — it depends on rapid repeated space characters arriving at stdin.

### Fix

Added explicit Space handling in `setupTerminalKeyBindings` that sends the space character directly to the PTY on each `keydown` event (including repeats), bypassing xterm.js's unreliable `keypress` path. Also calls `preventDefault()` to keep the hidden textarea clean.

Modifier combinations (Ctrl+Space, Alt+Space, etc.) are excluded and continue through xterm.js's normal pipeline.

## Test plan

- [ ] Open a Claude Code session in Switchboard
- [ ] Run `/voice` to enable voice mode
- [ ] Hold Space — should trigger audio recording (waveform appears)
- [ ] Release Space — recording should stop and transcribe
- [ ] Verify normal Space typing still works in shell prompts and editors
- [ ] Verify Ctrl+Space and other modified Space combos still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)