### PR TITLE
fix emoji/wide-character rendering in terminal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
+        "@xterm/addon-unicode-graphemes": "^0.4.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
@@ -2451,6 +2452,12 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
       "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-unicode-graphemes": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode-graphemes/-/addon-unicode-graphemes-0.4.0.tgz",
+      "integrity": "sha512-9+/CqwbKcnlkJU4d3wIgO+wjsL8f6vyz+UwUWLu6nADQz8Gr8ONqGCJfdDjIdI+yYZLABQqQy47FzEM6AWELjw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-unicode-graphemes": "^0.4.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -101,6 +101,7 @@
   <script src="../node_modules/@xterm/addon-fit/lib/addon-fit.js"></script>
   <script src="../node_modules/@xterm/addon-web-links/lib/addon-web-links.js"></script>
   <script src="../node_modules/@xterm/addon-search/lib/addon-search.js"></script>
+  <script src="../node_modules/@xterm/addon-unicode-graphemes/lib/addon-unicode-graphemes.js"></script>
   <script src="../node_modules/@xterm/addon-webgl/lib/addon-webgl.js"></script>
   <script src="../node_modules/morphdom/dist/morphdom-umd.js"></script>
   <script src="codemirror-bundle.js"></script>

--- a/public/terminal-manager.js
+++ b/public/terminal-manager.js
@@ -202,6 +202,8 @@ function createTerminalEntry(session) {
   }));
   const searchAddon = new SearchAddon.SearchAddon();
   terminal.loadAddon(searchAddon);
+  terminal.loadAddon(new UnicodeGraphemesAddon.UnicodeGraphemesAddon());
+  terminal.unicode.activeVersion = '15';
   terminal.open(container);
   container.style.backgroundColor = TERMINAL_THEME.background;
 


### PR DESCRIPTION
## Summary
- Adds `@xterm/addon-unicode-graphemes` to fix garbled text on lines containing emoji (✅, ❓, flags, ZWJ sequences)
- xterm.js defaults to Unicode 6.1 width tables which treat emoji as single-width, shifting all subsequent characters on the line
- The addon uses UAX #29 grapheme clustering (Unicode 15) for correct cell-width calculation

## Test plan
- [ ] Open a session that outputs emoji (e.g. Claude Code output with ✅/❓ markers)
- [ ] Verify characters after emoji are correctly aligned, no gaps or overlap
- [ ] Verify normal ASCII-only output is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)