### PR TITLE
Disable cursor blink to reduce idle CPU

### DIFF
--- a/public/terminal-manager.js
+++ b/public/terminal-manager.js
@@ -175,7 +175,7 @@ function createTerminalEntry(session) {
     fontSize: 12,
     fontFamily: "'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
     theme: TERMINAL_THEME,
-    cursorBlink: true,
+    cursorBlink: false,
     scrollback: 10000,
     convertEol: true,
     allowProposedApi: true,


### PR DESCRIPTION
## Summary
- Sets `cursorBlink: false` in xterm terminal options
- 5 idle terminals with cursor blink cause ~28% CPU from constant WebGL repaint cycles (requestAnimationFrame → draw call every ~500ms per terminal)
- With blink disabled, idle terminals drop to near-zero CPU

## Test plan
- [ ] Open 5+ terminals, leave them at shell prompt
- [ ] Monitor CPU — should be near-zero when idle
- [ ] Verify cursor is visible (solid block, no blink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)