### PR TITLE
fix: match Claude CLI's project-folder encoding (fixes #38, supersedes #37)

### DIFF
--- a/encode-project-path.js
+++ b/encode-project-path.js
@@ -1,0 +1,14 @@
+// Mirror Claude CLI's project-folder naming so Switchboard-created folders
+// match the ones the CLI writes for the same project path.
+// Reverse-engineered from claude CLI 2.1.126.
+function encodeProjectPath(projectPath) {
+  const sanitized = projectPath.replace(/[^a-zA-Z0-9]/g, '-');
+  if (sanitized.length <= 200) return sanitized;
+  let h = 0;
+  for (let i = 0; i < projectPath.length; i++) {
+    h = (h << 5) - h + projectPath.charCodeAt(i) | 0;
+  }
+  return sanitized.slice(0, 200) + '-' + Math.abs(h).toString(36);
+}
+
+module.exports = { encodeProjectPath };

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ const cleanPtyEnv = Object.fromEntries(
 // Shell profiles → shell-profiles.js
 const { discoverShellProfiles, getShellProfiles, resolveShell, isWindows, isWslShell, windowsToWslPath, shellArgs } = require('./shell-profiles');
 const { startScheduler } = require('./schedule-runner');
+const { encodeProjectPath } = require('./encode-project-path');
 
 
 
@@ -293,7 +294,7 @@ ipcMain.handle('add-project', (_event, projectPath) => {
     }
 
     // Create the corresponding folder in ~/.claude/projects/ so it persists
-    const folder = projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+    const folder = encodeProjectPath(projectPath);
     const folderPath = path.join(PROJECTS_DIR, folder);
     if (!fs.existsSync(folderPath)) {
       fs.mkdirSync(folderPath, { recursive: true });
@@ -329,7 +330,7 @@ ipcMain.handle('remove-project', (_event, projectPath) => {
     setSetting('global', global);
 
     // Clean up DB cache and search index for this folder
-    const folder = projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+    const folder = encodeProjectPath(projectPath);
     deleteCachedFolder(folder);
     deleteSearchFolder(folder);
     deleteSetting('project:' + projectPath);
@@ -981,7 +982,7 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
 
   if (!isPlainTerminal) {
     // Snapshot existing .jsonl files before spawning (for new session + fork/plan detection)
-    projectFolder = projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+    projectFolder = encodeProjectPath(projectPath);
     const claudeProjectDir = path.join(PROJECTS_DIR, projectFolder);
     if (fs.existsSync(claudeProjectDir)) {
       try {

--- a/public/app.js
+++ b/public/app.js
@@ -670,7 +670,7 @@ async function loadProjects({ resort = false } = {}) {
     const activeTerminals = await window.api.getActiveTerminals();
     for (const { sessionId, projectPath } of activeTerminals) {
       if (pendingSessions.has(sessionId)) continue; // already tracked
-      const folder = projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+      const folder = encodeProjectPath(projectPath);
       // Find the session object already injected by the backend
       let session;
       for (const proj of cachedAllProjects) {
@@ -709,7 +709,7 @@ async function launchNewSession(project, sessionOptions) {
   };
 
   // Track as pending (no .jsonl yet)
-  const folder = projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+  const folder = encodeProjectPath(projectPath);
   pendingSessions.set(sessionId, { session, projectPath, folder });
 
   // Inject into cached project data so it appears in sidebar immediately

--- a/public/dialogs.js
+++ b/public/dialogs.js
@@ -49,7 +49,7 @@ async function launchScheduleCreator(project) {
   };
 
   // Inject into sidebar
-  const folder = project.projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+  const folder = encodeProjectPath(project.projectPath);
   pendingSessions.set(result.sessionId, { session, projectPath: project.projectPath, folder });
   sessionMap.set(result.sessionId, session);
   for (const projList of [cachedProjects, cachedAllProjects]) {
@@ -141,7 +141,7 @@ async function launchTerminalSession(project) {
   };
 
   // Track as pending
-  const folder = projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+  const folder = encodeProjectPath(projectPath);
   pendingSessions.set(sessionId, { session, projectPath, folder });
 
   // Inject into cached project data

--- a/public/utils.js
+++ b/public/utils.js
@@ -1,5 +1,17 @@
 // --- Utility functions (shared across renderer modules) ---
 
+// Mirror Claude CLI's project-folder naming. Must stay in sync with
+// encode-project-path.js (main process). Reverse-engineered from claude CLI 2.1.126.
+function encodeProjectPath(projectPath) {
+  const sanitized = projectPath.replace(/[^a-zA-Z0-9]/g, '-');
+  if (sanitized.length <= 200) return sanitized;
+  let h = 0;
+  for (let i = 0; i < projectPath.length; i++) {
+    h = (h << 5) - h + projectPath.charCodeAt(i) | 0;
+  }
+  return sanitized.slice(0, 200) + '-' + Math.abs(h).toString(36);
+}
+
 function cleanDisplayName(name) {
   if (!name) return name;
   const prefix = 'Implement the following plan:';

--- a/schedule-ipc.js
+++ b/schedule-ipc.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const crypto = require('crypto');
+const { encodeProjectPath } = require('./encode-project-path');
 
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 const PROJECTS_DIR = path.join(CLAUDE_DIR, 'projects');
@@ -144,7 +145,7 @@ function init(log, runCommand) {
       const sessionId = crypto.randomUUID();
       const msgId = crypto.randomUUID();
       const timestamp = new Date().toISOString();
-      const folder = projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+      const folder = encodeProjectPath(projectPath);
       const claudeProjectDir = path.join(PROJECTS_DIR, folder);
 
       fs.mkdirSync(claudeProjectDir, { recursive: true });
@@ -191,7 +192,7 @@ function init(log, runCommand) {
       const dotClaudeDir = path.dirname(commandsDir);
       const projectPath = path.dirname(dotClaudeDir);
 
-      const folder = projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+      const folder = encodeProjectPath(projectPath);
       const schedule = {
         file: path.basename(filePath),
         filePath, projectPath, folder,

--- a/session-cache.js
+++ b/session-cache.js
@@ -4,6 +4,7 @@ const { Worker } = require('worker_threads');
 const { getFolderIndexMtimeMs } = require('./folder-index-state');
 const { deriveProjectPath } = require('./derive-project-path');
 const { readSessionFile } = require('./read-session-file');
+const { encodeProjectPath } = require('./encode-project-path');
 
 /**
  * Session cache module.
@@ -170,13 +171,13 @@ function buildProjectsFromCache(showArchived) {
   const global = getSetting('global') || {};
   const hiddenProjects = new Set(global.hiddenProjects || []);
 
-  // Group by folder (worktree sessions appear as separate projects)
+  // Group by folder (worktree sessions appear as separate projects).
+  // Only insert a project entry once we have a session that survives the
+  // archive filter — otherwise folders whose sessions are all archived would
+  // appear in the sidebar as undismissable phantom entries.
   const projectMap = new Map();
   for (const row of cachedRows) {
     if (hiddenProjects.has(row.projectPath)) continue;
-    if (!projectMap.has(row.folder)) {
-      projectMap.set(row.folder, { folder: row.folder, projectPath: row.projectPath, sessions: [] });
-    }
     const meta = metaMap.get(row.sessionId);
     const s = {
       sessionId: row.sessionId,
@@ -192,6 +193,9 @@ function buildProjectsFromCache(showArchived) {
       archived: meta?.archived || 0,
     };
     if (!showArchived && s.archived) continue;
+    if (!projectMap.has(row.folder)) {
+      projectMap.set(row.folder, { folder: row.folder, projectPath: row.projectPath, sessions: [] });
+    }
     projectMap.get(row.folder).sessions.push(s);
   }
 
@@ -212,7 +216,7 @@ function buildProjectsFromCache(showArchived) {
   // Inject active plain terminal sessions so they participate in sorting
   for (const [sessionId, session] of activeSessions) {
     if (session.exited || !session.isPlainTerminal) continue;
-    const folder = session.projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+    const folder = encodeProjectPath(session.projectPath);
     if (hiddenProjects.has(session.projectPath)) continue;
     if (!projectMap.has(folder)) {
       projectMap.set(folder, { folder, projectPath: session.projectPath, sessions: [] });


### PR DESCRIPTION
## Summary

Two bugs combined to produce undismissable duplicate project entries in the sidebar (#38). PR #37 partially addressed this for Windows drive paths; this PR fixes the root cause for all platforms by matching Claude CLI's encoding algorithm exactly.

### Bug 1 — folder-name encoding mismatch

Switchboard's regex `replace(/[/_]/g, '-')` only handled `/` and `_`. The Claude CLI normalizes **every** non-alphanumeric character and applies a 200-character cap with a deterministic hash suffix on overflow. So any path containing spaces, dots, backslashes (Windows), colons (Windows drive letters), or parentheses produced two different folder names — Switchboard's seed folder, and the CLI's actual session folder — both surfacing as the same project in the sidebar.

Reverse-engineered the CLI's algorithm from `claude` 2.1.126:

```js
function encodeProjectPath(p) {
  const s = p.replace(/[^a-zA-Z0-9]/g, '-');
  if (s.length <= 200) return s;
  let h = 0;
  for (let i = 0; i < p.length; i++) h = (h << 5) - h + p.charCodeAt(i) | 0;
  return s.slice(0, 200) + '-' + Math.abs(h).toString(36);
}
```

The hash is a Java-style `String.hashCode` truncated to int32. Pure and deterministic, so Switchboard now produces byte-identical folder names to the CLI for any project path.

### Bug 2 — phantom projects from archive filter ordering

In `session-cache.js:buildProjectsFromCache`, the project entry was added to `projectMap` *before* the `if (!showArchived && s.archived) continue` filter ran. Folders whose sessions were all archived ended up as empty `{ sessions: [] }` entries in the sidebar, and the archive button's `if (sessions.length === 0) return` made them undismissable. Fix: only insert into `projectMap` after the filter passes.

## Changes

- New `encode-project-path.js` — single source of truth for the encoder (main process)
- Mirror of the same function in `public/utils.js` for the renderer
- All 10 call sites across `main.js`, `session-cache.js`, `schedule-ipc.js`, `public/app.js`, `public/dialogs.js` now use `encodeProjectPath()`
- `session-cache.js` archive-filter ordering fix

## Migration note

Existing duplicate folders on disk from before this fix are left alone — auto-cleanup felt risky. Users with pre-existing dupes can `rm -rf ~/.claude/projects/<bad-folder-name>` manually. New projects added after this fix will encode correctly and merge with whatever the CLI creates.

## Relationship to #37

#37 widened the regex to `[\\/:_]` to cover Windows drive paths. This PR subsumes that fix — `[^a-zA-Z0-9]` covers `\` and `:` and everything else, and adds the missing 200-char cap + hash suffix branch. Recommend closing #37 in favor of this.

## Test plan

- [ ] macOS: add a project with spaces in the path (e.g. `/Users/you/My Project`) → folder created as `-Users-you-My-Project`, matches CLI when `claude` is run there
- [ ] macOS: project path with dots (e.g. `msci-6.1-upgrade`) → encodes consistently with CLI
- [ ] Windows: add a project on a non-C drive (e.g. `Q:\src\DevBox`) → folder created as `Q--src-DevBox`, no ENOENT
- [ ] Archive every session in a project → project disappears from sidebar (no phantom entry)
- [ ] Toggle "show archived" → archived-only projects reappear
- [ ] Empty project directory (no sessions in DB) still appears in sidebar (regression check on the empty-dirs pass)

Fixes #38.