### PR TITLE
fix: pick up ai-title entries so session names display

### DIFF
--- a/read-session-file.js
+++ b/read-session-file.js
@@ -13,11 +13,15 @@ function readSessionFile(filePath, folder, projectPath) {
     let textContent = '';
     let slug = null;
     let customTitle = null;
+    let aiTitle = null;
     for (const line of lines) {
       const entry = JSON.parse(line);
       if (entry.slug && !slug) slug = entry.slug;
       if (entry.type === 'custom-title' && entry.customTitle) {
         customTitle = entry.customTitle;
+      }
+      if (entry.type === 'ai-title' && entry.aiTitle) {
+        aiTitle = entry.aiTitle;
       }
       if (entry.type === 'user' || entry.type === 'assistant' ||
           (entry.type === 'message' && (entry.role === 'user' || entry.role === 'assistant'))) {
@@ -45,7 +49,7 @@ function readSessionFile(filePath, folder, projectPath) {
       summary, firstPrompt: summary,
       created: stat.birthtime.toISOString(),
       modified: stat.mtime.toISOString(),
-      messageCount, textContent, slug, customTitle,
+      messageCount, textContent, slug, customTitle: customTitle || aiTitle,
     };
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- Claude Code writes auto-generated session titles as `{"type":"ai-title","aiTitle":"…"}` jsonl entries, but `readSessionFile` only parsed `type:"custom-title"`, so AI titles were ignored and the sidebar fell back to the raw first prompt.
- Now also reads `ai-title`/`aiTitle`. User-set `customTitle` still wins; `aiTitle` is the fallback. Last-wins within each type, since Claude updates the AI title as the conversation evolves.

Fixes #33

## Test plan
- [ ] Open a session that has `ai-title` entries in its jsonl but no user rename — sidebar shows the AI-generated title instead of the raw first prompt
- [ ] Rename a session manually — `customTitle` continues to take precedence over any later `ai-title`
- [ ] Existing sessions named via rename still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)