### PR TITLE
fix: Merge project groups that resolve to the same projectPath

### DIFF
--- a/main.js
+++ b/main.js
@@ -262,7 +262,7 @@ sessionCache.init({
   db: {
     deleteCachedFolder, getCachedByFolder, upsertCachedSessions, deleteCachedSession,
     deleteSearchFolder, deleteSearchSession, upsertSearchEntries,
-    setFolderMeta, getAllMeta, getAllCached, getSetting, getMeta, setName,
+    setFolderMeta, getAllFolderMeta, getAllMeta, getAllCached, getSetting, getMeta, setName,
   },
 });
 const { readSessionFile, readFolderFromFilesystem, refreshFolder, populateCacheFromFilesystem,

--- a/session-cache.js
+++ b/session-cache.js
@@ -170,12 +170,16 @@ function buildProjectsFromCache(showArchived) {
   const global = getSetting('global') || {};
   const hiddenProjects = new Set(global.hiddenProjects || []);
 
-  // Group by folder (worktree sessions appear as separate projects)
+  // Group by projectPath. Multiple ~/.claude/projects/<folder>/ directories can resolve
+  // to the same projectPath (Claude Code's folder-name encoding scheme has changed over
+  // time, leaving stragglers), so we merge them into a single sidebar group to avoid
+  // duplicate-id collisions in the morphdom render.
   const projectMap = new Map();
   for (const row of cachedRows) {
+    if (!row.projectPath) continue;
     if (hiddenProjects.has(row.projectPath)) continue;
-    if (!projectMap.has(row.folder)) {
-      projectMap.set(row.folder, { folder: row.folder, projectPath: row.projectPath, sessions: [] });
+    if (!projectMap.has(row.projectPath)) {
+      projectMap.set(row.projectPath, { folder: row.folder, projectPath: row.projectPath, sessions: [] });
     }
     const meta = metaMap.get(row.sessionId);
     const s = {
@@ -192,7 +196,7 @@ function buildProjectsFromCache(showArchived) {
       archived: meta?.archived || 0,
     };
     if (!showArchived && s.archived) continue;
-    projectMap.get(row.folder).sessions.push(s);
+    projectMap.get(row.projectPath).sessions.push(s);
   }
 
   // Include empty project directories (no sessions yet)
@@ -200,11 +204,11 @@ function buildProjectsFromCache(showArchived) {
     const dirs = fs.readdirSync(PROJECTS_DIR, { withFileTypes: true })
       .filter(d => d.isDirectory() && d.name !== '.git');
     for (const d of dirs) {
-      if (!projectMap.has(d.name)) {
-        const projectPath = deriveProjectPath(path.join(PROJECTS_DIR, d.name), d.name);
-        if (projectPath && !hiddenProjects.has(projectPath)) {
-          projectMap.set(d.name, { folder: d.name, projectPath, sessions: [] });
-        }
+      const projectPath = deriveProjectPath(path.join(PROJECTS_DIR, d.name), d.name);
+      if (!projectPath) continue;
+      if (hiddenProjects.has(projectPath)) continue;
+      if (!projectMap.has(projectPath)) {
+        projectMap.set(projectPath, { folder: d.name, projectPath, sessions: [] });
       }
     }
   } catch {}
@@ -212,12 +216,13 @@ function buildProjectsFromCache(showArchived) {
   // Inject active plain terminal sessions so they participate in sorting
   for (const [sessionId, session] of activeSessions) {
     if (session.exited || !session.isPlainTerminal) continue;
-    const folder = session.projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+    if (!session.projectPath) continue;
     if (hiddenProjects.has(session.projectPath)) continue;
-    if (!projectMap.has(folder)) {
-      projectMap.set(folder, { folder, projectPath: session.projectPath, sessions: [] });
+    if (!projectMap.has(session.projectPath)) {
+      const folder = session.projectPath.replace(/[/_]/g, '-').replace(/^-/, '-');
+      projectMap.set(session.projectPath, { folder, projectPath: session.projectPath, sessions: [] });
     }
-    const proj = projectMap.get(folder);
+    const proj = projectMap.get(session.projectPath);
     if (!proj.sessions.some(s => s.sessionId === sessionId)) {
       proj.sessions.push({
         sessionId, summary: 'Terminal', firstPrompt: '', projectPath: session.projectPath,

--- a/session-cache.js
+++ b/session-cache.js
@@ -13,7 +13,7 @@ const { encodeProjectPath } = require('./encode-project-path');
 let PROJECTS_DIR, activeSessions, getMainWindow, log;
 let deleteCachedFolder, getCachedByFolder, upsertCachedSessions, deleteCachedSession;
 let deleteSearchFolder, deleteSearchSession, upsertSearchEntries;
-let setFolderMeta, getAllMeta, getAllCached, getSetting, getMeta, setName;
+let setFolderMeta, getAllFolderMeta, getAllMeta, getAllCached, getSetting, getMeta, setName;
 
 function init(ctx) {
   PROJECTS_DIR = ctx.PROJECTS_DIR;
@@ -29,6 +29,7 @@ function init(ctx) {
   deleteSearchSession = ctx.db.deleteSearchSession;
   upsertSearchEntries = ctx.db.upsertSearchEntries;
   setFolderMeta = ctx.db.setFolderMeta;
+  getAllFolderMeta = ctx.db.getAllFolderMeta;
   getAllMeta = ctx.db.getAllMeta;
   getAllCached = ctx.db.getAllCached;
   getSetting = ctx.db.getSetting;
@@ -198,21 +199,38 @@ function buildProjectsFromCache(showArchived) {
     };
     if (!showArchived && s.archived) continue;
     if (!projectMap.has(row.projectPath)) {
-      projectMap.set(row.projectPath, { folder: row.folder, projectPath: row.projectPath, sessions: [] });
+      projectMap.set(row.projectPath, {
+        folder: encodeProjectPath(row.projectPath),
+        projectPath: row.projectPath,
+        sessions: [],
+      });
     }
     projectMap.get(row.projectPath).sessions.push(s);
   }
 
-  // Include empty project directories (no sessions yet)
+  // Include empty project directories (no sessions yet). Resolve folder→projectPath
+  // through cache_meta (populated by the indexer) instead of re-reading a JSONL off
+  // disk for every directory on every render. Fall back to deriveProjectPath only
+  // for folders the indexer hasn't seen yet, and backfill cache_meta so subsequent
+  // renders are pure DB reads.
   try {
+    const folderMeta = getAllFolderMeta();
     const dirs = fs.readdirSync(PROJECTS_DIR, { withFileTypes: true })
       .filter(d => d.isDirectory() && d.name !== '.git');
     for (const d of dirs) {
-      const projectPath = deriveProjectPath(path.join(PROJECTS_DIR, d.name), d.name);
+      let projectPath = folderMeta.get(d.name)?.projectPath;
+      if (!projectPath) {
+        projectPath = deriveProjectPath(path.join(PROJECTS_DIR, d.name), d.name);
+        if (projectPath) setFolderMeta(d.name, projectPath, 0);
+      }
       if (!projectPath) continue;
       if (hiddenProjects.has(projectPath)) continue;
       if (!projectMap.has(projectPath)) {
-        projectMap.set(projectPath, { folder: d.name, projectPath, sessions: [] });
+        projectMap.set(projectPath, {
+          folder: encodeProjectPath(projectPath),
+          projectPath,
+          sessions: [],
+        });
       }
     }
   } catch {}


### PR DESCRIPTION
## Summary
- Two `~/.claude/projects/<folder>/` directories can resolve to the same project `cwd` because Claude Code's folder-name encoding scheme has changed over time (older runs encoded dots/spaces/`@` as dashes; newer runs preserve them literally). The sidebar rendered both folders as separate groups.
- Toggling the active-session filter (or any other re-render) accumulated extra duplicate DOM nodes — morphdom keys on `node.id`, and project-group ids derive from `projectPath`, so duplicate `projectPath` entries produced colliding ids that morphdom couldn't reconcile.
- `buildProjectsFromCache` now keys `projectMap` by `projectPath`, so cached rows, empty-folder fallback entries, and active-terminal injections from all encodings merge into one project group.

before
<img width="324" height="714" alt="image" src="https://github.com/user-attachments/assets/1d9bac1b-f122-46b3-8692-7c0d65766c00" />


## Test plan
- [x] Launch app — `My Drive/Obsidian Vault` (and any other project with two encoded folder names) shows as a single sidebar group with sessions from both folders.
- [x] Toggle the active-session filter several times; no duplicate groups accumulate.
- [x] Add a brand new project (no existing folder) — still appears.
- [x] Hide a duplicated project — both folder encodings disappear from the sidebar.
- [x] `npm test` still passes.