### PR TITLE
docs: add guide + script for customizing UI colors (light "Cowork" theme)

### DIFF
--- a/docs/customizing-colors.md
+++ b/docs/customizing-colors.md
@@ -1,0 +1,163 @@
+# Personnaliser les couleurs de Switchboard (fond + thème clair « Cowork »)
+
+> Guide pratique pour installer Switchboard, changer la couleur de fond, et appliquer un thème clair façon Claude / Cowork (fond crème, texte foncé, accent corail).
+>
+> Auteur : Jean-Luc PIETRI — 23/05/2026 — testé sur Switchboard v0.0.30 (Windows).
+
+---
+
+## 1. Présentation
+
+**Switchboard** (dépôt : `doctly/switchboard`, licence MIT) est une application de bureau qui centralise toutes vos sessions Claude Code dans une seule fenêtre : navigateur de sessions par projet, recherche plein texte, terminal intégré, fork/reprise de session, édition des fichiers `CLAUDE.md`, statistiques d'activité.
+
+L'interface est livrée avec un **thème sombre** bleu-violet. Comme l'application est construite avec Electron, son apparence est définie par une feuille de style CSS : on peut donc la modifier. Ce guide explique trois choses :
+
+1. installer Switchboard ;
+2. changer simplement la **couleur de fond** ;
+3. appliquer un **thème clair complet** aux couleurs de Claude / Cowork.
+
+> **Important** — La feuille de style est empaquetée dans une archive `app.asar`. Toute modification est **écrasée par la mise à jour automatique** de Switchboard à chaque nouvelle version : il faudra rejouer l'opération après un *update*.
+
+---
+
+## 2. Prérequis
+
+- **Switchboard installé**, avec des sessions Claude Code dans `~/.claude/projects` (sous Windows : `C:\Users\<vous>\.claude\projects`).
+- **Node.js 20+** et **npm** (fournissent la commande `npx`). L'outil `@electron/asar` est téléchargé automatiquement au besoin.
+- Sous Windows, si Switchboard est installé dans `Program Files`, ouvrez **PowerShell en administrateur** (les écritures y sont protégées).
+
+---
+
+## 3. Installer Switchboard
+
+1. Ouvrez la page des versions : `https://github.com/doctly/switchboard/releases/latest`
+2. Dans **Assets**, téléchargez l'installeur Windows `.exe` (type `Switchboard-Setup-x.y.z.exe`). *(macOS : `.dmg` ; Linux : `.AppImage` ou `.deb`.)*
+3. Lancez l'`.exe`. Comme l'application n'est pas signée, **SmartScreen** affichera « Windows a protégé votre PC » → cliquez sur **Informations complémentaires** puis **Exécuter quand même**.
+4. Suivez l'installeur. Au premier lancement, Switchboard scanne `~/.claude/projects` et liste vos sessions par projet.
+
+---
+
+## 4. Comprendre la personnalisation (`app.asar`)
+
+La CSS de l'interface se trouve dans `public/style.css`, **empaquetée** dans :
+
+```
+<dossier d'installation>\resources\app.asar
+```
+
+Chemins par défaut selon l'installation :
+
+- `C:\Users\<vous>\AppData\Local\Programs\Switchboard\resources\app.asar` (installation par utilisateur), ou
+- `C:\Program Files\Switchboard\resources\app.asar` / autre disque si vous avez changé le dossier.
+
+Pour modifier la CSS, il faut **extraire** l'archive, éditer le fichier, puis **ré-empaqueter**. Point crucial : les **modules natifs** (`better-sqlite3`, `node-pty`) doivent rester **hors** de l'archive (`--unpack-dir`), faute de quoi l'application ne démarre plus (Electron ne sait pas charger un module natif depuis l'intérieur d'un `.asar`).
+
+> Un `app.asar` reconstruit doit peser **~15-16 Mo**. S'il monte à ~50 Mo, c'est que les modules natifs ont été aspirés dans l'archive : l'option `--unpack-dir` a été oubliée.
+
+---
+
+## 5. Méthode A — Changer la couleur de fond (simple)
+
+Le fond principal sombre est la couleur `#111118`. Voici comment la remplacer par la couleur de votre choix (exemple : `#1e1e2e`).
+
+Ouvrez **PowerShell en administrateur**, puis adaptez le chemin d'installation :
+
+```powershell
+cd "D:\Program Files\Switchboard\resources"      # adaptez ce chemin
+Copy-Item app.asar app.asar.bak                   # sauvegarde (1re fois seulement)
+npx @electron/asar extract app.asar app_src
+(Get-Content app_src\public\style.css -Raw) -replace '#111118','#1e1e2e' | Set-Content app_src\public\style.css
+npx @electron/asar pack app_src app.asar --unpack-dir "node_modules/{better-sqlite3,node-pty}"
+```
+
+Relancez Switchboard. *(La même opération est automatisée par le script en mode `Solid` — voir section 7.)*
+
+---
+
+## 6. Méthode B — Appliquer le thème clair « Cowork »
+
+Passer d'un thème **sombre** à un thème **clair** n'est pas un simple échange de couleur : il faut convertir tout le châssis. Le principe appliqué :
+
+- **Fonds** sombres → crème (`#faf9f5`, `#f0eee6`, `#f4f2ec`, `#f7f5ef`).
+- **Texte** clair → foncé (`#141413` et nuances).
+- **Accent** bleu-violet (`#8088ff`) → **corail Claude** (`#d97757`).
+- **Voiles translucides blancs** (`rgba(255,255,255,…)`, utilisés pour bordures/survols sur fond sombre) → **voiles foncés** (`rgba(20,20,19,…)`).
+- Les **couleurs de statut** (vert / rouge / jaune) et les **blocs de code** (fond sombre conservé) sont laissés tels quels pour rester lisibles.
+
+La palette de référence est celle d'Anthropic / Claude :
+
+| Rôle | Couleur |
+|------|---------|
+| Fond crème | `#faf9f5` |
+| Texte principal | `#141413` |
+| Gris moyen | `#b0aea5` |
+| Accent corail | `#d97757` |
+| Bleu secondaire | `#6a9bcc` |
+
+Cette transformation touche des dizaines de couleurs ; le plus simple et le plus fiable est d'utiliser le **script automatique** ci-dessous.
+
+---
+
+## 7. Script automatique (recommandé)
+
+Le script `…_Switchboard-Personnalisation.ps1` (fourni avec ce guide) gère trois modes :
+
+| Mode | Effet |
+|------|-------|
+| `Cowork` | Applique le thème clair complet (défaut). |
+| `Solid`  | Remplace seulement le fond principal par `-Color`. |
+| `Revert` | Restaure l'original intact (`app.asar.bak`). |
+
+Il **repart toujours de la sauvegarde propre**, ferme l'application au besoin, et ré-empaquette en gardant les modules natifs dehors.
+
+Ouvrez **PowerShell en administrateur**, placez-vous dans le dossier du script, puis :
+
+```powershell
+# Thème clair Cowork
+.\2026-05-23_14-00-36_Switchboard-Personnalisation.ps1 -Mode Cowork
+
+# Fond uni d'une couleur précise
+.\2026-05-23_14-00-36_Switchboard-Personnalisation.ps1 -Mode Solid -Color '#101820'
+
+# Revenir à l'original
+.\2026-05-23_14-00-36_Switchboard-Personnalisation.ps1 -Mode Revert
+
+# Forcer un dossier d'installation particulier
+.\2026-05-23_14-00-36_Switchboard-Personnalisation.ps1 -Mode Cowork -InstallDir 'D:\Program Files\Switchboard'
+```
+
+Si l'exécution de scripts est bloquée, autorisez-la pour la session courante :
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+À la fin, le script affiche la taille du nouvel `app.asar` (doit être ~15-16 Mo) et relance l'application.
+
+---
+
+## 8. Revenir en arrière
+
+- **Original (thème sombre d'origine)** :
+
+  ```powershell
+  Copy-Item app.asar.bak app.asar -Force
+  ```
+
+  ou `.\…_Switchboard-Personnalisation.ps1 -Mode Revert`.
+
+- **Sécurité** : conservez toujours `app.asar.bak`. C'est votre filet de secours.
+
+---
+
+## 9. Réserves et limites
+
+- **Mise à jour automatique** : Switchboard se met à jour seul (au lancement et toutes les 4 h) ; chaque nouvelle version réécrit `app.asar` et **annule** la personnalisation. Relancez alors le script.
+- **Application non signée** : l'avertissement Windows à l'installation est normal.
+- **Terminal** : la zone terminal (xterm) a son propre thème, réglable directement dans **Réglages → Terminal Theme** (Switchboard, Ghostty, Tokyo Night, Catppuccin Mocha, Dracula, Nord, Solarized Dark).
+- **Thème clair = premier jet** : la conversion sombre → clair est volontairement « best-effort ». Si une zone vous paraît peu lisible, ajustez le bloc de correctifs en fin de `style.css` (section « correctifs zone conversation » du script).
+- **Version testée** : Switchboard v0.0.30. Une refonte de la CSS dans une version future peut nécessiter d'adapter la table de correspondance.
+
+---
+
+*Document rédigé par Jean-Luc PIETRI — 23/05/2026.*

--- a/scripts/apply-theme.ps1
+++ b/scripts/apply-theme.ps1
@@ -1,0 +1,196 @@
+<#
+=====================================================================
+ Switchboard - Personnalisation des couleurs
+ ---------------------------------------------------------------------
+ Modifie la CSS empaquetee dans app.asar (app Electron Switchboard).
+
+ 3 modes :
+   Cowork  -> theme clair facon Claude / Cowork
+              (fond creme #faf9f5, texte #141413, accent corail #d97757)
+   Solid   -> remplace simplement la couleur de fond principale (-Color)
+   Revert  -> restaure l'original intact (app.asar.bak)
+
+ Le script repart TOUJOURS de la sauvegarde propre (app.asar.bak) et
+ re-empaquette en gardant les modules natifs (better-sqlite3, node-pty)
+ HORS de l'asar (--unpack-dir), sinon l'application casse.
+
+ PREREQUIS : Node.js 20+ et npm (fournit npx). @electron/asar est
+ telecharge automatiquement par npx au besoin.
+
+ IMPORTANT : si Switchboard est installe dans "Program Files", lancez
+ ce script dans une fenetre PowerShell ouverte EN ADMINISTRATEUR.
+
+ ATTENTION : la mise a jour automatique de Switchboard reecrit app.asar
+ a chaque nouvelle version -> il faut relancer ce script apres un update.
+
+ Auteur : Jean-Luc PIETRI
+ Date    : 23/05/2026
+=====================================================================
+.EXAMPLE
+  .\2026-05-23_14-00-36_Switchboard-Personnalisation.ps1 -Mode Cowork
+.EXAMPLE
+  .\2026-05-23_14-00-36_Switchboard-Personnalisation.ps1 -Mode Solid -Color '#101820'
+.EXAMPLE
+  .\2026-05-23_14-00-36_Switchboard-Personnalisation.ps1 -Mode Revert
+.EXAMPLE
+  .\2026-05-23_14-00-36_Switchboard-Personnalisation.ps1 -Mode Cowork -InstallDir 'D:\Program Files\Switchboard'
+#>
+
+param(
+  [string]$InstallDir,
+  [ValidateSet('Cowork','Solid','Revert')] [string]$Mode = 'Cowork',
+  [string]$Color = '#1e1e2e',
+  [switch]$NoRestart
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------
+# 1. Localiser l'installation de Switchboard
+# ---------------------------------------------------------------------
+if (-not $InstallDir) {
+  $candidats = @(
+    "$env:LOCALAPPDATA\Programs\Switchboard",
+    "$env:ProgramFiles\Switchboard",
+    "${env:ProgramFiles(x86)}\Switchboard",
+    "D:\Program Files\Switchboard",
+    "C:\Program Files\Switchboard"
+  )
+  $InstallDir = $candidats | Where-Object { Test-Path (Join-Path $_ 'resources\app.asar') } | Select-Object -First 1
+}
+if (-not $InstallDir -or -not (Test-Path (Join-Path $InstallDir 'resources\app.asar'))) {
+  Write-Error "Switchboard introuvable. Relancez avec : -InstallDir 'C:\chemin\vers\Switchboard'"
+  return
+}
+
+$resources = Join-Path $InstallDir 'resources'
+$asar      = Join-Path $resources 'app.asar'
+$bak       = Join-Path $resources 'app.asar.bak'
+$appsrc    = Join-Path $resources 'app_src'
+$cssPath   = Join-Path $appsrc   'public\style.css'
+$exe       = Join-Path $InstallDir 'Switchboard.exe'
+
+Write-Host "Installation : $InstallDir"  -ForegroundColor Cyan
+Write-Host "Mode         : $Mode"        -ForegroundColor Cyan
+
+# ---------------------------------------------------------------------
+# 2. Fermer Switchboard (sinon app.asar est verrouille)
+# ---------------------------------------------------------------------
+Get-Process Switchboard -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Milliseconds 800
+
+# ---------------------------------------------------------------------
+# 3. Sauvegarde initiale propre (une seule fois)
+# ---------------------------------------------------------------------
+if (-not (Test-Path $bak)) {
+  Copy-Item $asar $bak -Force
+  Write-Host "Sauvegarde de l'original creee : app.asar.bak" -ForegroundColor Yellow
+}
+
+# ---------------------------------------------------------------------
+# Mode REVERT : restaurer l'original puis quitter
+# ---------------------------------------------------------------------
+if ($Mode -eq 'Revert') {
+  Copy-Item $bak $asar -Force
+  Write-Host "Original restaure (app.asar.bak)." -ForegroundColor Green
+  if (-not $NoRestart) { Start-Process $exe }
+  return
+}
+
+# ---------------------------------------------------------------------
+# 4. Repartir du propre, puis extraire l'asar
+# ---------------------------------------------------------------------
+Copy-Item $bak $asar -Force
+if (Test-Path $appsrc) { Remove-Item $appsrc -Recurse -Force }
+npx @electron/asar extract $asar $appsrc
+
+$css = Get-Content -Raw $cssPath
+
+# ---------------------------------------------------------------------
+# 5. Transformation des couleurs selon le mode
+# ---------------------------------------------------------------------
+if ($Mode -eq 'Solid') {
+
+  # Remplace les fonds principaux par la couleur demandee
+  foreach ($bg in '#0e0e14','#111118','#1e1e2e') {
+    $css = $css -replace ([regex]::Escape($bg) + '\b'), $Color
+  }
+  Write-Host "Fond principal remplace par $Color" -ForegroundColor Green
+
+}
+elseif ($Mode -eq 'Cowork') {
+
+  # Table de correspondance sombre -> clair (chassis de l'application).
+  # NB : aucune valeur cible n'est elle-meme une cle (pas d'effet de chaine).
+  $map = [ordered]@{
+    '#0e0e14'='#f4f2ec'; '#111118'='#faf9f5'; '#1e1e2e'='#faf9f5'; '#18181f'='#f7f5ef'; '#1a1a2e'='#f0eee6';
+    '#4a4a5a'='#e3e0d6'; '#555570'='#ddd9ce'; '#5a5a70'='#ddd9ce'; '#606078'='#9a978d'; '#606878'='#9a978d';
+    '#6a6a80'='#8a8780'; '#707088'='#84817a'; '#777790'='#7c7a72'; '#7a7a90'='#6e6c64'; '#7a7a96'='#6e6c64';
+    '#808090'='#6b6962'; '#808098'='#6b6962'; '#8888a0'='#64625b'; '#8888a8'='#64625b'; '#8a8aa0'='#64625b';
+    '#909098'='#5e5c56'; '#9090a8'='#5e5c56'; '#9898b0'='#595751'; '#a0a0b8'='#54524c'; '#b0b0c4'='#46443f';
+    '#b0b0d0'='#46443f'; '#b0b8c8'='#46443f'; '#b8b8cc'='#403e3a'; '#c0c0d0'='#36342f'; '#c0c0d8'='#36342f';
+    '#c0c1d8'='#36342f'; '#d0d0e0'='#2a2925'; '#d0d0e8'='#2a2925'; '#d8d8f0'='#222019'; '#e0e0e0'='#141413';
+    '#e0e0f0'='#141413'; '#f0f0ff'='#141413'; '#8088ff'='#d97757'; '#6a72e0'='#bd5d3f'; '#6068b0'='#bd5d3f';
+    '#555'='#8a8780'; '#666'='#8a8780'; '#888'='#6b6962'; '#999'='#5e5c56'; '#ffffff'='#141413'; '#fff'='#141413';
+  }
+  # Cles longues d'abord ; la frontiere \b evite de couper un hex plus long.
+  foreach ($k in ($map.Keys | Sort-Object { $_.Length } -Descending)) {
+    $css = $css -replace ([regex]::Escape($k) + '\b'), $map[$k]
+  }
+
+  # Voiles translucides : blanc -> fonce ; accent bleu -> corail.
+  $css = $css -replace 'rgba\(\s*255\s*,\s*255\s*,\s*255\s*,', 'rgba(20,20,19,'
+  $css = $css -replace 'rgba\(\s*128\s*,\s*136\s*,\s*255\s*,', 'rgba(217,119,87,'
+  $css = $css -replace 'rgba\(\s*120\s*,\s*130\s*,\s*255\s*,', 'rgba(217,119,87,'
+
+  # Correctifs de la zone conversation (corps fonce, code clair sur fond
+  # sombre conserve, liens lisibles). Ajoutes en fin de fichier -> priorite.
+  $override = @'
+
+/* === Theme clair Cowork : correctifs zone conversation === */
+.markdown-preview { color:#141413; }
+.markdown-preview h1,.markdown-preview h2,.markdown-preview h3,.markdown-preview h4,.markdown-preview h5,.markdown-preview h6 { color:#141413; }
+.markdown-preview a { color:#3a6ea5; }
+.markdown-preview th { color:#141413; }
+.markdown-preview pre { background:#282a36; }
+.markdown-preview pre, .markdown-preview pre code { color:#f1efe9; }
+.jsonl-text { color:#141413; }
+.jsonl-text a { color:#3a6ea5; }
+.jsonl-text a:hover { color:#28527d; }
+.jsonl-text th { color:#141413; }
+.jsonl-text :not(pre) > code { color:#9a3fb8; background:rgba(20,20,19,0.06); }
+.jsonl-text pre { background:#282a36; color:#f1efe9; }
+.jsonl-tool-name { color:#3a6ea5; }
+.jsonl-meta-entry code { color:#6b4a86; }
+.jsonl-tool-call .jsonl-toggle { color:#9a3fb8; }
+'@
+  $css = $css + "`r`n" + $override
+  Write-Host "Theme clair Cowork applique." -ForegroundColor Green
+}
+
+# Ecriture UTF-8 sans BOM (chemin absolu requis pour .NET)
+[System.IO.File]::WriteAllText($cssPath, $css)
+
+# ---------------------------------------------------------------------
+# 6. Re-empaqueter en gardant les modules natifs dehors
+# ---------------------------------------------------------------------
+npx @electron/asar pack $appsrc $asar --unpack-dir "node_modules/{better-sqlite3,node-pty}"
+
+$sizeMo = [math]::Round((Get-Item $asar).Length / 1MB, 1)
+Write-Host "app.asar reconstruit : $sizeMo Mo (attendu ~15-16 Mo)." -ForegroundColor Green
+if ($sizeMo -gt 30) {
+  Write-Warning "Taille anormale (>30 Mo) : les modules natifs ont peut-etre ete empaquetes. Verifiez le --unpack-dir."
+}
+
+# Nettoyage du dossier temporaire d'extraction
+Remove-Item $appsrc -Recurse -Force -ErrorAction SilentlyContinue
+
+# ---------------------------------------------------------------------
+# 7. Relancer l'application
+# ---------------------------------------------------------------------
+if (-not $NoRestart) {
+  Start-Process $exe
+  Write-Host "Switchboard relance." -ForegroundColor Green
+} else {
+  Write-Host "Termine. Relancez Switchboard manuellement." -ForegroundColor Green
+}


### PR DESCRIPTION
## What
Adds documentation and a helper script for customizing Switchboard's UI colors:

- `docs/customizing-colors.md` — how to change the background color and apply a light
  "Cowork/Claude" theme (cream background, dark text, coral accent), and how to revert.
- `scripts/apply-theme.ps1` — Windows helper with three modes:
  `Cowork` (light theme), `Solid -Color <hex>` (single background color), and `Revert`.
  It repacks `app.asar` while keeping native modules unpacked (`--unpack-dir`).

## Why
The app background is currently hard-coded in `public/style.css` and only the terminal
theme is configurable in-app. This documents a safe, reversible way to recolor the UI.

## Notes
- Tested on Switchboard v0.0.30 (Windows).
- No source code changed — docs + helper script only.
- The script edits the packaged `style.css`; a built-in theming option would obviously be
  a cleaner long-term solution. Happy to reframe this as a feature request if you prefer.