### PR TITLE
Open external links once (dedupe OSC 8 + WebLinks double-open)

### DIFF
--- a/main.js
+++ b/main.js
@@ -126,13 +126,13 @@ function createWindow() {
 
   // Open external links in the system browser instead of a child BrowserWindow
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (/^https?:\/\//i.test(url)) shell.openExternal(url).catch(() => {});
+    openExternalOnce(url);
     return { action: 'deny' };
   });
   mainWindow.webContents.on('will-navigate', (event, url) => {
     if (url !== mainWindow.webContents.getURL()) {
       event.preventDefault();
-      if (/^https?:\/\//i.test(url)) shell.openExternal(url).catch(() => {});
+      openExternalOnce(url);
     }
   });
   // Override window.open so xterm WebLinksAddon's default handler (which does
@@ -343,9 +343,26 @@ ipcMain.handle('remove-project', (_event, projectPath) => {
 });
 
 // --- IPC: get-projects ---
+// Open an external URL, collapsing duplicate requests for the same URL within a
+// short window. A terminal URL can be matched by BOTH xterm's OSC 8 link provider
+// (via the linkHandler option) and the WebLinksAddon regex when a hyperlink's
+// visible text is itself a URL — common with CLIs like Claude Code that emit OSC 8.
+// Both fire on a single click, so the browser would otherwise open twice.
+let _lastExternalUrl = null;
+let _lastExternalAt = 0;
+function openExternalOnce(url) {
+  if (!/^https?:\/\//i.test(url)) return;
+  const now = Date.now();
+  if (url === _lastExternalUrl && now - _lastExternalAt < 700) return;
+  _lastExternalUrl = url;
+  _lastExternalAt = now;
+  return shell.openExternal(url).catch(() => {});
+}
+
+// --- IPC: open-external ---
 ipcMain.handle('open-external', (_event, url) => {
   log.info('[open-external IPC]', url);
-  if (/^https?:\/\//i.test(url)) return shell.openExternal(url);
+  return openExternalOnce(url);
 });
 
 // --- IPC: MCP bridge ---


### PR DESCRIPTION
## Problem

Clicking a link in a session terminal opens it in the browser **twice**.

A URL printed in the terminal can be matched by two link providers at once:

- xterm's built-in **OSC 8** link provider, driven by the `linkHandler` option, and
- the **`WebLinksAddon`** regex provider,

whenever an OSC 8 hyperlink's *visible text* is itself a URL. Modern CLIs — notably Claude Code — now emit OSC 8 hyperlinks routinely, so this overlap is hit on ordinary links. Both providers' `activate` callbacks fire on a single click, each calls `window.api.openExternal`, and the browser opens the link twice. (That's why it's a recent regression even though the link code didn't change — the *input* did.)

## Fix

Funnel external opens through a small `openExternalOnce()` that drops a repeat of the **same URL within 700 ms**, and route the `open-external` IPC handler plus the `setWindowOpenHandler` / `will-navigate` handlers through it.

```js
function openExternalOnce(url) {
  if (!/^https?:\/\//i.test(url)) return;
  const now = Date.now();
  if (url === _lastExternalUrl && now - _lastExternalAt < 700) return;
  _lastExternalUrl = url; _lastExternalAt = now;
  return shell.openExternal(url).catch(() => {});
}
```

This keeps **every** link type working — plain URLs (WebLinks), OSC 8 `http(s)` and `file://` (the `linkHandler` path) — and only suppresses the duplicate open. Deduping at the sink (rather than dropping a provider) avoids regressing either plain-text URL detection or OSC 8 / `file://`→panel handling.

## Testing

Built locally (Electron 41, Linux) and confirmed terminal links that previously opened twice now open once; plain URLs and `file://` links still work. No automated test added — `main.js` isn't import-structured for `node --test`, and the change is a guard around `shell.openExternal`.
