### PR TITLE
Don't apply the worktree default when resuming a session

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -793,6 +793,11 @@ async function openSession(session, customOptions) {
 
   // Open terminal in main process
   const resumeOptions = customOptions || await resolveDefaultSessionOptions({ projectPath });
+  // The `worktree` default applies to NEW sessions only. Resuming must reuse the
+  // session's existing directory, so never pass --worktree on resume — otherwise
+  // a plain-click resume tries to spin up a fresh git worktree and fails to attach
+  // (the Resume-with-config dialog already omits worktree, which is why it works).
+  if (resumeOptions) { delete resumeOptions.worktree; delete resumeOptions.worktreeName; }
   const result = await window.api.openTerminal(sessionId, projectPath, false, resumeOptions);
   if (!result.ok) {
     entry.terminal.write(`\r\nError: ${result.error}\r\n`);


### PR DESCRIPTION
## Problem

A plain click on a session in the sidebar does nothing — no terminal appears, the session stays "inactive" — yet **Resume with config** works. So a session can only be interacted with through the config dialog.

## Cause

`openSession()` resumes with `resolveDefaultSessionOptions()`, which is shared with new-session creation and includes the global `worktree: true` default. Resuming an **existing** session with `--worktree` tries to spin it up in a fresh git worktree and fails to attach, so the terminal never shows.

`showResumeSessionDialog()` has **no** worktree control and never sets the flag — which is exactly why "Resume with config" works. Plain click and the dialog should behave the same.

## Fix

Strip `worktree`/`worktreeName` from the resolved options on the resume path in `openSession()`:

```js
const resumeOptions = customOptions || await resolveDefaultSessionOptions({ projectPath });
if (resumeOptions) { delete resumeOptions.worktree; delete resumeOptions.worktreeName; }
```

New-session creation is untouched (still honors the worktree default). Worktree is a *new-session* concept — resuming must reuse the session's existing directory.

## Testing

Built locally (Electron 41, Linux) with `worktree: true` as the default: plain click now resumes in place and attaches, matching the dialog. New-session-in-worktree still works.
