### PR TITLE
perf(app): poll active sessions adaptively (3s active, 30s idle)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -531,6 +531,22 @@ terminalStopBtn.addEventListener('click', () => {
 
 
 // --- Poll for active PTY sessions ---
+// Adaptive cadence: poll fast (3s) only while PTYs are running; when idle, back
+// off to 30s. Every renderer path that starts a session (launchNewSession,
+// openSession, launchTerminalSession, onSessionDetected/Forked) calls
+// pollActiveSessions() explicitly, which re-arms the fast cadence immediately.
+// The 30s idle floor still catches sessions started outside the renderer
+// (scheduler-spawned PTYs, other windows) within at most 30s.
+const POLL_FAST_MS = 3000;
+const POLL_IDLE_MS = 30000;
+let pollTimer = null;
+
+function scheduleActiveSessionsPoll() {
+  if (pollTimer) clearTimeout(pollTimer);
+  const delay = activePtyIds.size > 0 ? POLL_FAST_MS : POLL_IDLE_MS;
+  pollTimer = setTimeout(pollActiveSessions, delay);
+}
+
 async function pollActiveSessions() {
   try {
     const ids = await window.api.getActiveSessions();
@@ -538,6 +554,7 @@ async function pollActiveSessions() {
     updateRunningIndicators();
     updateTerminalHeader();
   } catch {}
+  scheduleActiveSessionsPoll();
 }
 
 function updateRunningIndicators() {
@@ -592,10 +609,11 @@ function updatePtyTitle() {
   terminalHeaderPtyTitle.style.display = title ? '' : 'none';
 }
 
-setInterval(pollActiveSessions, 3000);
+scheduleActiveSessionsPoll();
 
 // Refresh sidebar timeago labels every 30s so "just now" ticks forward
 setInterval(() => {
+  if (lastActivityTime.size === 0) return;
   for (const [sessionId, time] of lastActivityTime) {
     const item = document.getElementById('si-' + sessionId);
     if (!item) continue;


### PR DESCRIPTION
## Problem

The renderer polls active PTY sessions every 3s unconditionally via `setInterval(pollActiveSessions, 3000)`. Each tick performs an IPC round-trip (`getActiveSessions`) plus a full-sidebar `querySelectorAll` sweep in `updateRunningIndicators()` — even when zero sessions are running. On an idle app this is steady, pointless CPU churn.

## Fix

Poll adaptively:

- `pollActiveSessions()` now re-arms itself via `scheduleActiveSessionsPoll()`, which schedules the next tick at **3s while any PTY is running** (`activePtyIds.size > 0`) and **30s when idle**.
- Every renderer code path that starts a session already calls `pollActiveSessions()` explicitly, so an in-renderer session start re-arms the fast cadence immediately.
- The 30s idle floor still catches sessions started outside the renderer (e.g. scheduler-spawned PTYs) within at most 30s.
- The sidebar timeago `setInterval` now no-ops when `lastActivityTime` is empty.

## Notes

Behavior-preserving: identical polling work and indicator updates while sessions run; the only change is cadence when idle. Syntax-checked (`node --check`); the test suite passes.
