### PR TITLE
fix(terminal): don't hijack Space during IME composition (Korean input)

### DIFF
--- a/public/terminal-manager.js
+++ b/public/terminal-manager.js
@@ -13,7 +13,27 @@
 // Two layers needed:
 //   1. attachCustomKeyEventHandler returning false — blocks xterm's key pipeline (onKey/onData)
 //   2. preventDefault on capture-phase keydown — prevents browser inserting \n into textarea
-const isMac = window.api.platform === 'darwin';
+const isMac = typeof window !== 'undefined' && window.api && window.api.platform === 'darwin';
+
+// True when a keydown is being consumed by an IME (e.g. Korean/Japanese/Chinese)
+// to compose a character. Chromium reports keyCode 229 for such keydowns, and
+// sets isComposing while a composition is active. xterm's own _keyDown defers to
+// its composition helper in this state — but only if our custom handler lets the
+// event through (returns true) instead of intercepting it.
+function isImeComposing(e) {
+  return e.isComposing === true || e.keyCode === 229;
+}
+
+// Whether a Space keydown should be written straight to the PTY (the push-to-talk
+// key-repeat path from #22) rather than left to xterm. It must NOT fire during IME
+// composition: preventDefault-ing the Space there drops the in-progress syllable
+// (e.g. Korean "녕 " came out as " 녕" or lost the syllable entirely).
+function shouldSendSpaceDirectly(e) {
+  return e.key === ' '
+    && !e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey
+    && !isImeComposing(e);
+}
+
 function setupTerminalKeyBindings(terminal, container, getSessionId, { onFind } = {}) {
   terminal.attachCustomKeyEventHandler((e) => {
     // Cmd/Ctrl+F → open terminal search bar
@@ -76,7 +96,10 @@ function setupTerminalKeyBindings(terminal, container, getSessionId, { onFind } 
     // for key-repeat events. This fixes Claude Code's "Hold Space to record"
     // push-to-talk voice feature, which depends on rapid key-repeat characters
     // arriving at stdin to detect a held key.
-    if (e.key === ' ' && !e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey) {
+    // Skips IME composition (isImeComposing): during Korean/Japanese/Chinese
+    // composition, Space commits the pending syllable, so it must fall through
+    // to xterm's composition helper instead of being sent raw.
+    if (shouldSendSpaceDirectly(e)) {
       if (e.type === 'keydown') {
         e.preventDefault();
         window.api.sendInput(getSessionId(), ' ');
@@ -365,4 +388,10 @@ function setupDragAndDrop(container, getSessionId) {
     const paths = Array.from(files).map(f => shellEscape(window.api.getPathForFile(f)));
     window.api.sendInput(getSessionId(), paths.join(' '));
   });
+}
+
+// Expose pure key-handling predicates to Node for unit testing. No-op in the
+// browser, where this file is loaded as a plain <script> and `module` is undefined.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { isImeComposing, shouldSendSpaceDirectly };
 }

--- a/test/terminal-input.test.js
+++ b/test/terminal-input.test.js
@@ -1,0 +1,48 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { shouldSendSpaceDirectly } = require('../public/terminal-manager');
+
+// Build a keydown-like event with sensible defaults (plain Space, no IME).
+function kd(overrides = {}) {
+  return {
+    key: ' ',
+    type: 'keydown',
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    shiftKey: false,
+    isComposing: false,
+    keyCode: 32,
+    ...overrides,
+  };
+}
+
+test('plain Space (no IME) is sent directly to the PTY for push-to-talk key-repeat', () => {
+  // The reason the direct-send path exists (#22): xterm's keydown path drops
+  // plain Space, breaking Claude Code's "Hold Space to record".
+  assert.equal(shouldSendSpaceDirectly(kd()), true);
+});
+
+test('Space during IME composition is NOT sent directly (isComposing)', () => {
+  // Regression fix: intercepting this Space with preventDefault dropped/mangled
+  // the in-progress Hangul syllable. Must defer to xterm's composition helper.
+  assert.equal(shouldSendSpaceDirectly(kd({ isComposing: true })), false);
+});
+
+test('Space during IME composition is NOT sent directly (keyCode 229 sentinel)', () => {
+  // Chromium reports keyCode 229 for keydowns consumed by the IME, and some
+  // IMEs do not set isComposing on the committing keystroke.
+  assert.equal(shouldSendSpaceDirectly(kd({ keyCode: 229 })), false);
+});
+
+test('Space combined with a modifier is not the push-to-talk path', () => {
+  assert.equal(shouldSendSpaceDirectly(kd({ ctrlKey: true })), false);
+  assert.equal(shouldSendSpaceDirectly(kd({ metaKey: true })), false);
+  assert.equal(shouldSendSpaceDirectly(kd({ altKey: true })), false);
+  assert.equal(shouldSendSpaceDirectly(kd({ shiftKey: true })), false);
+});
+
+test('non-Space keys are never on the direct-send path', () => {
+  assert.equal(shouldSendSpaceDirectly(kd({ key: 'a', keyCode: 65 })), false);
+});


### PR DESCRIPTION
## Problem

Korean (and any IME-composed) input is corrupted in terminals: pressing space between words drops or reorders the in-progress Hangul syllable — e.g. typing `녕 ` produces ` 녕` or loses the syllable entirely. This makes CLI sessions nearly unusable for Korean/Japanese/Chinese typists.

## Root cause

The push-to-talk Space handler added in #22 (`public/terminal-manager.js`) intercepts **every** plain-Space `keydown`, calls `e.preventDefault()`, writes a raw `' '` straight to the PTY, and returns `false`.

The problem is ordering. In xterm's `_keyDown`, the custom key handler runs **before** the IME composition helper:

```js
if (this._customKeyEventHandler && false === this._customKeyEventHandler(e)) return false; // ← runs FIRST
if (!t && !this._compositionHelper.keydown(e)) return ..., false;                          // ← IME check runs AFTER
```

During Korean composition, the Space `keydown` fires with `isComposing === true` / `keyCode === 229`. The handler `preventDefault`s it (blocking the composition commit), sends a raw space out of order, and returns `false` so `_compositionHelper.keydown()` never runs. Since Korean is space-separated, this breaks essentially every word.

## Fix

Gate the direct-send path on `!isImeComposing(e)` so it only fires when no IME is composing — which is exactly when push-to-talk needs it. During composition the event now falls through to xterm's composition helper for correct commit behavior.

```js
function isImeComposing(e) { return e.isComposing === true || e.keyCode === 229; }

function shouldSendSpaceDirectly(e) {
  return e.key === ' '
    && !e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey
    && !isImeComposing(e);
}
```

Push-to-talk (Hold Space to record) is unaffected: with no IME composing, `isComposing` is false and `keyCode` is `32`, so the direct-send path still fires on every key-repeat.

## Testing

- Extracted the decision into a pure, exported predicate and added `test/terminal-input.test.js` (5 cases: plain space → direct send; composing via `isComposing`; composing via `keyCode 229`; modifier combos; non-space keys).
- `npm test` → all green.
- Not yet verified with live IME typing in the running app — reviewers with a Korean/Japanese/Chinese input source can confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
