### PR TITLE
Add remote SSH sessions (Phase 2): index, search & resume past sessions

### DIFF
--- a/db.js
+++ b/db.js
@@ -2,19 +2,22 @@ const Database = require('better-sqlite3');
 const path = require('path');
 const os = require('os');
 
-const DATA_DIR = path.join(os.homedir(), '.switchboard');
+// DB location is overridable via env (used by tests to point at a temp file so
+// they never touch the real ~/.switchboard/switchboard.db).
+const DATA_DIR = process.env.SWITCHBOARD_DATA_DIR || path.join(os.homedir(), '.switchboard');
 const fs = require('fs');
 if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
 
-const DB_PATH = path.join(DATA_DIR, 'switchboard.db');
+const DB_PATH = process.env.SWITCHBOARD_DB_PATH || path.join(DATA_DIR, 'switchboard.db');
 
-// Migrate from old locations if needed
+// Migrate from old locations if needed (skipped when an explicit DB path is set,
+// so tests don't move the user's real data into a temp file).
 const OLD_LOCATIONS = [
   path.join(os.homedir(), '.claude', 'browser', 'switchboard.db'),
   path.join(os.homedir(), '.claude', 'browser', 'session-browser.db'),
   path.join(os.homedir(), '.claude', 'session-browser.db'),
 ];
-if (!fs.existsSync(DB_PATH)) {
+if (!process.env.SWITCHBOARD_DB_PATH && !fs.existsSync(DB_PATH)) {
   for (const oldPath of OLD_LOCATIONS) {
     if (fs.existsSync(oldPath)) {
       fs.renameSync(oldPath, DB_PATH);
@@ -49,7 +52,8 @@ db.exec(`
     modified TEXT,
     messageCount INTEGER DEFAULT 0,
     slug TEXT,
-    aiTitle TEXT
+    aiTitle TEXT,
+    source TEXT
   )
 `);
 
@@ -99,6 +103,12 @@ const migrations = [
     try { db.exec('DELETE FROM session_cache'); } catch {}
     try { db.exec('DELETE FROM cache_meta'); } catch {}
   },
+  // v4: Add source column (NULL = local, hostId = remote host) for Phase 2 remote
+  // session indexing. No cache wipe — existing rows are local, and NULL means local.
+  (db) => {
+    try { db.exec('ALTER TABLE session_cache ADD COLUMN source TEXT'); } catch {}
+    try { db.exec('ALTER TABLE search_map ADD COLUMN source TEXT'); } catch {}
+  },
 ];
 
 const currentDbVersion = (() => {
@@ -127,7 +137,8 @@ db.exec(`
     rowid INTEGER PRIMARY KEY,
     id TEXT NOT NULL,
     type TEXT NOT NULL,
-    folder TEXT
+    folder TEXT,
+    source TEXT
   )
 `);
 
@@ -152,20 +163,27 @@ const stmts = {
   cacheCount: db.prepare('SELECT COUNT(*) as cnt FROM session_cache'),
   cacheGetAll: db.prepare('SELECT * FROM session_cache'),
   cacheUpsert: db.prepare(`
-    INSERT INTO session_cache (sessionId, folder, projectPath, summary, firstPrompt, created, modified, messageCount, slug, aiTitle)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO session_cache (sessionId, folder, projectPath, summary, firstPrompt, created, modified, messageCount, slug, aiTitle, source)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(sessionId) DO UPDATE SET
       folder = excluded.folder, projectPath = excluded.projectPath,
       summary = excluded.summary, firstPrompt = excluded.firstPrompt,
       created = excluded.created, modified = excluded.modified,
       messageCount = excluded.messageCount, slug = excluded.slug,
-      aiTitle = excluded.aiTitle
+      aiTitle = excluded.aiTitle, source = excluded.source
   `),
-  cacheGetByFolder: db.prepare('SELECT sessionId, modified FROM session_cache WHERE folder = ?'),
+  // Local incremental refresh must not see remote rows (a remote encoded-folder
+  // name could collide with a local folder name), so scope to source IS NULL.
+  cacheGetByFolder: db.prepare('SELECT sessionId, modified FROM session_cache WHERE folder = ? AND source IS NULL'),
+  cacheGetBySource: db.prepare('SELECT sessionId, modified FROM session_cache WHERE source = ?'),
+  cacheGetIdsBySourceProject: db.prepare('SELECT sessionId FROM session_cache WHERE source = ? AND projectPath = ?'),
+  cacheDeleteBySourceProject: db.prepare('DELETE FROM session_cache WHERE source = ? AND projectPath = ?'),
+  cacheGetIdsByProjectRemote: db.prepare('SELECT sessionId FROM session_cache WHERE projectPath = ? AND source IS NOT NULL'),
+  cacheDeleteByProjectRemote: db.prepare('DELETE FROM session_cache WHERE projectPath = ? AND source IS NOT NULL'),
   cacheGetFolder: db.prepare('SELECT folder FROM session_cache WHERE sessionId = ?'),
   cacheGetSession: db.prepare('SELECT * FROM session_cache WHERE sessionId = ?'),
   cacheDeleteSession: db.prepare('DELETE FROM session_cache WHERE sessionId = ?'),
-  cacheDeleteFolder: db.prepare('DELETE FROM session_cache WHERE folder = ?'),
+  cacheDeleteFolder: db.prepare('DELETE FROM session_cache WHERE folder = ? AND source IS NULL'),
   // Cache meta statements
   metaGet: db.prepare('SELECT * FROM cache_meta WHERE folder = ?'),
   metaGetAll: db.prepare('SELECT * FROM cache_meta'),
@@ -179,12 +197,12 @@ const stmts = {
   // FTS search statements
   searchDeleteBySession: db.prepare('DELETE FROM search_fts WHERE rowid IN (SELECT rowid FROM search_map WHERE type = \'session\' AND id = ?)'),
   searchMapDeleteBySession: db.prepare('DELETE FROM search_map WHERE type = \'session\' AND id = ?'),
-  searchDeleteByFolder: db.prepare('DELETE FROM search_fts WHERE rowid IN (SELECT rowid FROM search_map WHERE type = \'session\' AND folder = ?)'),
-  searchMapDeleteByFolder: db.prepare('DELETE FROM search_map WHERE type = \'session\' AND folder = ?'),
+  searchDeleteByFolder: db.prepare('DELETE FROM search_fts WHERE rowid IN (SELECT rowid FROM search_map WHERE type = \'session\' AND folder = ? AND source IS NULL)'),
+  searchMapDeleteByFolder: db.prepare('DELETE FROM search_map WHERE type = \'session\' AND folder = ? AND source IS NULL'),
   searchDeleteByType: db.prepare('DELETE FROM search_fts WHERE rowid IN (SELECT rowid FROM search_map WHERE type = ?)'),
   searchMapDeleteByType: db.prepare('DELETE FROM search_map WHERE type = ?'),
   searchInsertFts: db.prepare('INSERT OR REPLACE INTO search_fts(rowid, title, body) VALUES (?, ?, ?)'),
-  searchInsertMap: db.prepare('INSERT OR REPLACE INTO search_map(id, type, folder) VALUES (?, ?, ?)'),
+  searchInsertMap: db.prepare('INSERT OR REPLACE INTO search_map(id, type, folder, source) VALUES (?, ?, ?, ?)'),
   searchMapLookup: db.prepare('SELECT rowid FROM search_map WHERE id = ? AND type = ?'),
   searchUpdateTitle: db.prepare('UPDATE search_fts SET title = ? WHERE rowid = (SELECT rowid FROM search_map WHERE id = ? AND type = ?)'),
   searchDeleteByRowid: db.prepare('DELETE FROM search_fts WHERE rowid = ?'),
@@ -246,7 +264,7 @@ const upsertCachedSessionsBatch = db.transaction((sessions) => {
     stmts.cacheUpsert.run(
       s.sessionId, s.folder, s.projectPath, s.summary,
       s.firstPrompt, s.created, s.modified, s.messageCount || 0,
-      s.slug || null, s.aiTitle || null
+      s.slug || null, s.aiTitle || null, s.source || null
     );
   }
 });
@@ -257,6 +275,39 @@ function upsertCachedSessions(sessions) {
 
 function getCachedByFolder(folder) {
   return stmts.cacheGetByFolder.all(folder);
+}
+
+function getCachedBySource(source) {
+  return stmts.cacheGetBySource.all(source);
+}
+
+/** Remove all cached + indexed sessions for one remote project (host + projectPath). */
+const deleteRemoteProjectCacheTx = db.transaction((source, projectPath) => {
+  const ids = stmts.cacheGetIdsBySourceProject.all(source, projectPath).map(r => r.sessionId);
+  for (const id of ids) {
+    stmts.searchDeleteBySession.run(id);
+    stmts.searchMapDeleteBySession.run(id);
+  }
+  stmts.cacheDeleteBySourceProject.run(source, projectPath);
+});
+
+function deleteRemoteProjectCache(source, projectPath) {
+  deleteRemoteProjectCacheTx(source, projectPath);
+}
+
+// Same, but keyed only by projectPath (any remote source). Used to remove an
+// auto-discovered remote project group that was never explicitly registered.
+const deleteRemoteProjectCacheByPathTx = db.transaction((projectPath) => {
+  const ids = stmts.cacheGetIdsByProjectRemote.all(projectPath).map(r => r.sessionId);
+  for (const id of ids) {
+    stmts.searchDeleteBySession.run(id);
+    stmts.searchMapDeleteBySession.run(id);
+  }
+  stmts.cacheDeleteByProjectRemote.run(projectPath);
+});
+
+function deleteRemoteProjectCacheByPath(projectPath) {
+  deleteRemoteProjectCacheByPathTx(projectPath);
 }
 
 function getCachedFolder(sessionId) {
@@ -306,7 +357,7 @@ const upsertSearchEntriesBatch = db.transaction((entries) => {
       stmts.searchDeleteByRowid.run(existing.rowid);
       stmts.searchMapDeleteByRowid.run(existing.rowid);
     }
-    const result = stmts.searchInsertMap.run(e.id, e.type, e.folder || null);
+    const result = stmts.searchInsertMap.run(e.id, e.type, e.folder || null, e.source || null);
     stmts.searchInsertFts.run(result.lastInsertRowid, e.title || '', e.body || '');
   }
 });
@@ -376,8 +427,8 @@ function closeDb() {
 
 module.exports = {
   getMeta, getAllMeta, setName, toggleStar, setArchived,
-  isCachePopulated, getAllCached, getCachedByFolder, getCachedFolder, getCachedSession, upsertCachedSessions,
-  deleteCachedSession, deleteCachedFolder,
+  isCachePopulated, getAllCached, getCachedByFolder, getCachedBySource, getCachedFolder, getCachedSession, upsertCachedSessions,
+  deleteCachedSession, deleteCachedFolder, deleteRemoteProjectCache, deleteRemoteProjectCacheByPath,
   getFolderMeta, getAllFolderMeta, setFolderMeta,
   upsertSearchEntries, updateSearchTitle, deleteSearchSession, deleteSearchFolder, deleteSearchType,
   searchByType, isSearchIndexPopulated, searchFtsRecreated,

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ const cleanPtyEnv = Object.fromEntries(
 // Shell profiles → shell-profiles.js
 const { discoverShellProfiles, getShellProfiles, resolveShell, isWindows, isWslShell, windowsToWslPath, shellArgs, isSshProfile } = require('./shell-profiles');
 const remoteHosts = require('./remote-hosts');
+const remoteIndex = require('./remote-index');
 const { startScheduler } = require('./schedule-runner');
 const { encodeProjectPath } = require('./encode-project-path');
 
@@ -62,8 +63,8 @@ if (app.isPackaged || process.env.FORCE_UPDATER) {
 }
 const {
   getMeta, getAllMeta, toggleStar, setName, setArchived,
-  isCachePopulated, getAllCached, getCachedByFolder, getCachedFolder, getCachedSession, upsertCachedSessions,
-  deleteCachedSession, deleteCachedFolder,
+  isCachePopulated, getAllCached, getCachedByFolder, getCachedBySource, getCachedFolder, getCachedSession, upsertCachedSessions,
+  deleteCachedSession, deleteCachedFolder, deleteRemoteProjectCache, deleteRemoteProjectCacheByPath,
   getFolderMeta, getAllFolderMeta, setFolderMeta,
   upsertSearchEntries, updateSearchTitle, deleteSearchSession, deleteSearchFolder, deleteSearchType,
   searchByType, isSearchIndexPopulated, searchFtsRecreated,
@@ -327,8 +328,14 @@ ipcMain.handle('remove-project', (_event, projectPath) => {
     if (typeof projectPath === 'string' && projectPath.startsWith('ssh://')) {
       const global = getSetting('global') || {};
       global.remoteProjects = (global.remoteProjects || []).filter(p => p.projectPath !== projectPath);
+      // Auto-discovered remote groups aren't in remoteProjects, so also hide the
+      // path (a re-sync would otherwise re-surface it) and drop its indexed rows.
+      const hidden = global.hiddenProjects || [];
+      if (!hidden.includes(projectPath)) hidden.push(projectPath);
+      global.hiddenProjects = hidden;
       setSetting('global', global);
       deleteSetting('project:' + projectPath);
+      try { deleteRemoteProjectCacheByPath(projectPath); } catch {}
       notifyRendererProjectsChanged();
       return { ok: true };
     }
@@ -1005,6 +1012,64 @@ ipcMain.handle('remote-browse', (_event, { hostId, path: remotePath } = {}) => {
   });
 });
 
+// Index a connected host's past remote sessions (Phase 2). Reuses the live
+// ControlMaster socket; transcripts are read over SSH and never copied to disk.
+// Returns { ok, indexed, deleted } or { ok:false, needsAuth } when no live master.
+// `quiet` suppresses the status-bar chatter (used by the silent startup sweep).
+async function runRemoteSync(hostId, { quiet = false } = {}) {
+  const global = getSetting('global') || {};
+  const manual = global.remoteHosts || [];
+  const host = remoteHosts.findRemoteHost(hostId, manual);
+  if (!host) return { ok: false, error: 'unknown host' };
+  const sock = remoteHosts.controlSocketPath(os.tmpdir(), host.id);
+  const label = host.label || host.alias || host.id;
+  if (!quiet) sendStatus('Syncing remote sessions from ' + label + '…', 'active');
+  try {
+    const res = await remoteIndex.syncRemoteHost({
+      host, sock, hostLabel: label,
+      db: { getCachedBySource, upsertCachedSessions, upsertSearchEntries, deleteCachedSession, deleteSearchSession, getMeta, setName },
+    });
+    log.info(`[remote-sync] host=${host.id} indexed=${res.indexed} deleted=${res.deleted}`);
+    notifyRendererProjectsChanged();
+    if (!quiet) {
+      const msg = res.indexed > 0
+        ? `Indexed ${res.indexed} remote session${res.indexed === 1 ? '' : 's'} from ${label}`
+        : `No new remote sessions on ${label}`;
+      sendStatus(msg, 'done');
+      setTimeout(() => sendStatus(''), 4000);
+    }
+    return res;
+  } catch (err) {
+    const emsg = (err && err.message) || String(err);
+    log.info(`[remote-sync] host=${host.id} FAILED: ${emsg}`);
+    if (!quiet) {
+      sendStatus(`Couldn't sync ${label} — connect to the host first.`, 'error');
+      setTimeout(() => sendStatus(''), 5000);
+    }
+    return { ok: false, error: emsg, needsAuth: true };
+  }
+}
+
+ipcMain.handle('sync-remote-host', async (_event, hostId) => {
+  return runRemoteSync(hostId);
+});
+
+// On startup, silently try to index each registered remote host. Key/agent-auth
+// hosts (or ones with a still-live ControlMaster) index without any prompt via
+// BatchMode; password hosts fail fast and are simply skipped until the user
+// connects. Runs in the background so it never blocks the UI.
+function startupRemoteSync() {
+  const global = getSetting('global') || {};
+  // Every host the user has touched: registered remote projects + manual hosts.
+  const ids = [...new Set([
+    ...(global.remoteProjects || []).map((p) => p.hostId),
+    ...(global.remoteHosts || []).map((h) => h.id),
+  ].filter(Boolean))];
+  for (const id of ids) {
+    runRemoteSync(id, { quiet: true }).catch(() => {});
+  }
+}
+
 // --- Scheduled tasks ---
 const scheduleIpc = require('./schedule-ipc');
 
@@ -1088,7 +1153,22 @@ ipcMain.handle('rename-session', (_event, sessionId, name) => {
 });
 
 // --- IPC: archive-session ---
-ipcMain.handle('read-session-jsonl', (_event, sessionId) => {
+ipcMain.handle('read-session-jsonl', async (_event, sessionId) => {
+  const cached = getCachedSession(sessionId);
+  // Remote (Phase 2): stream the transcript live over SSH — nothing is copied to disk.
+  if (cached && cached.source) {
+    const global = getSetting('global') || {};
+    const manual = global.remoteHosts || [];
+    const host = remoteHosts.findRemoteHost(cached.source, manual);
+    if (!host) return { error: 'unknown remote host' };
+    const sock = remoteHosts.controlSocketPath(os.tmpdir(), host.id);
+    try {
+      const entries = await remoteIndex.fetchRemoteSessionEntries({ host, sock, folder: cached.folder, sessionId });
+      return { entries };
+    } catch (err) {
+      return { needsConnect: true, hostLabel: host.label || host.id };
+    }
+  }
   const folder = getCachedFolder(sessionId);
   if (!folder) return { error: 'Session not found in cache' };
   const jsonlPath = path.join(PROJECTS_DIR, folder, sessionId + '.jsonl');
@@ -1239,8 +1319,6 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
       const remoteMode = sessionOptions?.remoteMode === 'shell' ? 'shell' : 'claude';
       let innerCmd = null;
       if (remoteMode === 'claude') {
-        // Phase 1 launches a fresh remote Claude session; --session-id/--resume
-        // are managed on the remote host and wired up in a later milestone.
         let cc = 'claude';
         if (sessionOptions?.dangerouslySkipPermissions) {
           cc += ' --dangerously-skip-permissions';
@@ -1250,6 +1328,13 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
         if (sessionOptions?.addDirs) {
           const dirs = sessionOptions.addDirs.split(',').map(d => d.trim()).filter(Boolean);
           for (const dir of dirs) cc += ` --add-dir "${dir}"`;
+        }
+        // Resume / fork a past remote session on the host (the transcript lives
+        // there — same --resume the CLI uses locally, run in the session's dir).
+        if (sessionOptions?.forkFrom) {
+          cc += ` --resume "${sessionOptions.forkFrom}" --fork-session`;
+        } else if (sessionOptions?.resume) {
+          cc += ` --resume "${sessionOptions.resume}"`;
         }
         innerCmd = cc;
       }
@@ -1497,6 +1582,13 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
     activeSessions.delete(realId);
     // Clean up the original key too in case transition detection hasn't run yet
     activeSessions.delete(sessionId);
+
+    // A remote Claude session just wrote/updated its transcript on the host —
+    // re-index that host so the past session shows up in the sidebar/search.
+    if (session.remote && session.remoteHost && session.remoteMode !== 'shell') {
+      const hid = session.remoteHost.id;
+      setTimeout(() => { runRemoteSync(hid).catch(() => {}); }, 1500);
+    }
   });
 
   if (sessionOptions?.forkFrom) {
@@ -1644,6 +1736,9 @@ app.whenReady().then(() => {
   createWindow();
   startProjectsWatcher();
   scheduleIpc.ensureScheduleCreatorCommand();
+  // Index already-reachable remote hosts in the background (Phase 2), so past
+  // remote sessions show up on launch without a manual connect/refresh.
+  setTimeout(() => { try { startupRemoteSync(); } catch {} }, 2000);
 
   // Shared runCommand for both cron scheduler and manual "run now"
   const { spawn: cpSpawn } = require('child_process');

--- a/main.js
+++ b/main.js
@@ -26,7 +26,8 @@ const cleanPtyEnv = Object.fromEntries(
 );
 
 // Shell profiles → shell-profiles.js
-const { discoverShellProfiles, getShellProfiles, resolveShell, isWindows, isWslShell, windowsToWslPath, shellArgs } = require('./shell-profiles');
+const { discoverShellProfiles, getShellProfiles, resolveShell, isWindows, isWslShell, windowsToWslPath, shellArgs, isSshProfile } = require('./shell-profiles');
+const remoteHosts = require('./remote-hosts');
 const { startScheduler } = require('./schedule-runner');
 const { encodeProjectPath } = require('./encode-project-path');
 
@@ -322,6 +323,15 @@ ipcMain.handle('add-project', (_event, projectPath) => {
 // --- IPC: remove-project ---
 ipcMain.handle('remove-project', (_event, projectPath) => {
   try {
+    // Remote projects live in settings only (no local .claude/projects folder).
+    if (typeof projectPath === 'string' && projectPath.startsWith('ssh://')) {
+      const global = getSetting('global') || {};
+      global.remoteProjects = (global.remoteProjects || []).filter(p => p.projectPath !== projectPath);
+      setSetting('global', global);
+      deleteSetting('project:' + projectPath);
+      notifyRendererProjectsChanged();
+      return { ok: true };
+    }
     // Add to hidden projects list
     const global = getSetting('global') || {};
     const hidden = global.hiddenProjects || [];
@@ -807,6 +817,194 @@ ipcMain.handle('delete-setting', (_event, key) => {
   return { ok: true };
 });
 
+// --- IPC: remote SSH hosts (Phase 1) ---
+
+// Merged list of remote targets: parsed from ~/.ssh/config plus user-defined
+// manual hosts persisted in global settings under `remoteHosts`.
+ipcMain.handle('get-remote-targets', () => {
+  const manual = (getSetting('global') || {}).remoteHosts || [];
+  return remoteHosts.loadRemoteHosts(manual);
+});
+
+// Persist the manual host list (config-derived hosts are never written back).
+ipcMain.handle('save-remote-hosts', (_event, hosts) => {
+  const global = getSetting('global') || {};
+  const clean = (Array.isArray(hosts) ? hosts : [])
+    .filter(h => h && h.host && String(h.host).trim())
+    .map(h => ({
+      id: h.id || undefined,
+      label: (h.label || '').trim() || undefined,
+      host: String(h.host).trim(),
+      user: (h.user || '').trim() || undefined,
+      port: h.port ? Number(h.port) : undefined,
+      identityFile: (h.identityFile || '').trim() || undefined,
+      options: h.options,
+    }))
+    .map(remoteHosts.normalizeManualHost);
+  global.remoteHosts = clean;
+  setSetting('global', global);
+  return { ok: true, hosts: remoteHosts.loadRemoteHosts(clean) };
+});
+
+// Interactive Connect: authenticate/verify a host inline (not in the sidebar).
+// Runs `ssh -tt <control> <target> true` in a PTY: after auth the trivial command
+// exits (code 0 = connected) while ControlPersist keeps the connection warm for
+// Browse/sessions. Prompts (password/passphrase/host key) are streamed to a small
+// popup terminal in the renderer so the user answers there.
+const _connectProcs = new Map();
+let _connectSeq = 0;
+
+ipcMain.handle('remote-connect-start', (_event, hostId) => {
+  const manual = (getSetting('global') || {}).remoteHosts || [];
+  const host = remoteHosts.findRemoteHost(hostId, manual);
+  if (!host) return { error: 'unknown host' };
+  const sock = remoteHosts.controlSocketPath(os.tmpdir(), host.id);
+  const args = ['-tt', ...remoteHosts.controlArgs(sock), ...remoteHosts.hostTargetArgs(host), 'true'];
+  const connectId = ++_connectSeq;
+  let proc;
+  try {
+    proc = pty.spawn('ssh', args, { name: 'xterm-256color', cols: 80, rows: 16, cwd: os.homedir(), env: cleanPtyEnv });
+  } catch (err) {
+    return { error: err.message };
+  }
+  _connectProcs.set(connectId, proc);
+  const send = (channel, ...a) => { if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send(channel, ...a); };
+  proc.onData(d => send('remote-connect-data', connectId, d));
+  proc.onExit(({ exitCode }) => {
+    _connectProcs.delete(connectId);
+    send('remote-connect-exit', connectId, exitCode);
+  });
+  return { connectId };
+});
+
+ipcMain.on('remote-connect-input', (_event, connectId, data) => {
+  const proc = _connectProcs.get(connectId);
+  if (proc) { try { proc.write(data); } catch {} }
+});
+
+ipcMain.handle('remote-connect-cancel', (_event, connectId) => {
+  const proc = _connectProcs.get(connectId);
+  if (proc) { try { proc.kill(); } catch {} }
+  _connectProcs.delete(connectId);
+  return { ok: true };
+});
+
+// Append a host as a proper ~/.ssh/config entry (append-only, backed up once,
+// skips if an entry with that alias already exists).
+ipcMain.handle('write-ssh-config', (_event, host) => {
+  try {
+    if (!host || !host.host) return { error: 'host is required' };
+    const h = remoteHosts.normalizeManualHost(host);
+    const cfgPath = remoteHosts.defaultSshConfigPath();
+    const dir = path.dirname(cfgPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const existing = fs.existsSync(cfgPath) ? fs.readFileSync(cfgPath, 'utf8') : '';
+    // Dedup: does a Host line already list this alias as a whole word?
+    const aliasRe = new RegExp('^\\s*Host\\s+(.*\\s)?' + h.label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(\\s.*)?$', 'mi');
+    if (aliasRe.test(existing)) return { error: `Host "${h.label}" already exists in ~/.ssh/config` };
+    // One-time backup before the first Switchboard-written change.
+    const bak = cfgPath + '.switchboard.bak';
+    if (existing && !fs.existsSync(bak)) fs.writeFileSync(bak, existing, { mode: 0o600 });
+    const block = (existing && !existing.endsWith('\n') ? '\n' : '') + '\n# added by Switchboard\n' + remoteHosts.buildSshConfigEntry(h) + '\n';
+    fs.appendFileSync(cfgPath, block, { mode: 0o600 });
+    notifyRendererProjectsChanged();
+    return { ok: true, path: cfgPath, label: h.label };
+  } catch (err) {
+    return { error: err.message };
+  }
+});
+
+// Non-interactive connectivity probe (key/agent auth only; never prompts).
+ipcMain.handle('test-remote-host', (_event, hostId) => {
+  const manual = (getSetting('global') || {}).remoteHosts || [];
+  const host = remoteHosts.findRemoteHost(hostId, manual);
+  if (!host) return Promise.resolve({ ok: false, error: 'unknown host' });
+  return new Promise((resolve) => {
+    let out = '';
+    let done = false;
+    const finish = (result) => { if (!done) { done = true; resolve(result); } };
+    let proc;
+    try {
+      proc = pty.spawn('ssh', remoteHosts.testConnectionArgs(host), {
+        name: 'xterm-256color', cols: 80, rows: 24, cwd: os.homedir(), env: cleanPtyEnv,
+      });
+    } catch (err) {
+      return finish({ ok: false, error: err.message });
+    }
+    const killTimer = setTimeout(() => {
+      try { proc.kill(); } catch {}
+      finish({ ok: false, status: 'unreachable', reachable: false, message: 'Timed out', output: out.trim() });
+    }, 15000);
+    proc.onData(d => { out += d; if (out.length > 4000) out = out.slice(-4000); });
+    proc.onExit(({ exitCode }) => {
+      clearTimeout(killTimer);
+      // BatchMode never prompts, so a password-auth host "fails" but is reachable.
+      // Classify the output so the UI reports reachability honestly.
+      const cls = remoteHosts.classifyConnResult(exitCode, out);
+      finish({ ok: cls.reachable, exitCode, ...cls, output: out.trim() });
+    });
+  });
+});
+
+// --- IPC: remote projects (Model A — a project can be local or remote) ---
+
+// Register a remote project (host + remote directory) that appears in the
+// sidebar alongside local projects. Persisted in global settings.
+ipcMain.handle('add-remote-project', (_event, { hostId, remotePath } = {}) => {
+  try {
+    const global = getSetting('global') || {};
+    const manual = global.remoteHosts || [];
+    const host = remoteHosts.findRemoteHost(hostId, manual);
+    if (!host) return { error: 'unknown host' };
+    const dir = (remotePath && String(remotePath).trim()) ? String(remotePath).trim() : '~';
+    const projectPath = remoteHosts.remoteProjectPath(host.label, dir);
+    const list = global.remoteProjects || [];
+    if (!list.some(p => p.projectPath === projectPath)) {
+      list.push({ projectPath, hostId: host.id, hostLabel: host.label, remotePath: dir });
+      global.remoteProjects = list;
+      setSetting('global', global);
+    }
+    notifyRendererProjectsChanged();
+    return { ok: true, projectPath, hostId: host.id, hostLabel: host.label, remotePath: dir };
+  } catch (err) {
+    return { error: err.message };
+  }
+});
+
+// List directories at a remote path (for the remote directory browser). Uses the
+// shared control socket (BatchMode = never prompts). If the host needs interactive
+// auth and has no live connection yet, this fails fast with needsAuth so the UI can
+// tell the user to open a session first (which authenticates and persists the master).
+ipcMain.handle('remote-browse', (_event, { hostId, path: remotePath } = {}) => {
+  const manual = (getSetting('global') || {}).remoteHosts || [];
+  const host = remoteHosts.findRemoteHost(hostId, manual);
+  if (!host) return Promise.resolve({ ok: false, error: 'unknown host' });
+  const dir = (remotePath && String(remotePath).trim()) ? String(remotePath).trim() : '~';
+  const sock = remoteHosts.controlSocketPath(os.tmpdir(), host.id);
+  const args = remoteHosts.browseArgs(host, sock, dir);
+  return new Promise((resolve) => {
+    let out = '', err = '', done = false;
+    const finish = (r) => { if (!done) { done = true; resolve(r); } };
+    let proc;
+    try {
+      proc = pty.spawn('ssh', args, { name: 'xterm-256color', cols: 80, rows: 24, cwd: os.homedir(), env: cleanPtyEnv });
+    } catch (e) {
+      return finish({ ok: false, error: e.message });
+    }
+    const killTimer = setTimeout(() => { try { proc.kill(); } catch {} finish({ ok: false, error: 'timed out', path: dir }); }, 12000);
+    // pty merges stdout/stderr; classify on non-zero exit.
+    proc.onData(d => { out += d; if (out.length > 20000) out = out.slice(-20000); });
+    proc.onExit(({ exitCode }) => {
+      clearTimeout(killTimer);
+      if (exitCode === 0) {
+        return finish({ ok: true, path: dir, dirs: remoteHosts.parseLsDirs(out) });
+      }
+      const cls = remoteHosts.classifyConnResult(exitCode, out);
+      finish({ ok: false, path: dir, needsAuth: cls.reachable && cls.status !== 'unreachable', status: cls.status, message: cls.message, output: out.trim().slice(-500) });
+    });
+  });
+});
+
 // --- Scheduled tasks ---
 const scheduleIpc = require('./schedule-ipc');
 
@@ -942,45 +1140,70 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
     return { ok: true, reattached: true, mcpActive: !!session.mcpServer };
   }
 
-  // Spawn new PTY
-  if (!fs.existsSync(projectPath)) {
+  const isPlainTerminal = sessionOptions?.type === 'terminal';
+
+  // Remote (SSH) session? Resolve the host + ssh profile up front so we can skip
+  // local-filesystem checks below. Remote sessions run over `ssh` and their
+  // project directory lives on the remote host, not locally.
+  const remoteHostId = sessionOptions?.remoteHostId || null;
+  let remoteHost = null;
+  if (remoteHostId) {
+    const manual = (getSetting('global') || {}).remoteHosts || [];
+    remoteHost = remoteHosts.findRemoteHost(remoteHostId, manual);
+    if (!remoteHost) return { ok: false, error: `unknown remote host: ${remoteHostId}` };
+  }
+  const isRemote = !!remoteHost;
+
+  // Spawn new PTY. Local sessions require an existing project directory; remote
+  // sessions do not (the directory is on the remote host).
+  if (!isRemote && !fs.existsSync(projectPath)) {
     return { ok: false, error: `project directory no longer exists: ${projectPath}` };
   }
 
-  const isPlainTerminal = sessionOptions?.type === 'terminal';
-
-  // Resolve shell profile from effective settings
-  const effectiveProfileId = (() => {
-    const global = getSetting('global') || {};
-    const project = projectPath ? (getSetting('project:' + projectPath) || {}) : {};
-    let profileId = SETTING_DEFAULTS.shellProfile;
-    if (global.shellProfile !== undefined && global.shellProfile !== null) profileId = global.shellProfile;
-    if (project.shellProfile !== undefined && project.shellProfile !== null) profileId = project.shellProfile;
-    return profileId;
-  })();
-  // WSL profiles only work for plain terminals — Claude CLI sessions need the
-  // Windows shell because session data lives on the Windows filesystem.
-  const requestedProfile = resolveShell(effectiveProfileId);
-  const useWslProfile = isWslShell(requestedProfile.path) && isPlainTerminal;
-  const shellProfile = (isWslShell(requestedProfile.path) && !isPlainTerminal)
-    ? resolveShell('auto')
-    : requestedProfile;
-  const shell = shellProfile.path;
-  const shellExtraArgs = [...(shellProfile.args || [])];
-  const isWsl = isWslShell(shell);
-  // For WSL, convert Windows path to /mnt/ path and pass via --cd;
-  // the spawn cwd must remain a valid Windows path for wsl.exe itself.
-  if (isWsl) {
-    const wslCwd = windowsToWslPath(projectPath);
-    shellExtraArgs.unshift('--cd', wslCwd);
+  // Resolve the shell to spawn.
+  let shell, shellExtraArgs, isWsl;
+  if (isRemote) {
+    shell = 'ssh';
+    // -t (PTY) + connection multiplexing (shared control socket) + target. The
+    // control socket lets the directory browser reuse this authenticated
+    // connection, so the user only authenticates once per host.
+    const sock = remoteHosts.controlSocketPath(os.tmpdir(), remoteHost.id);
+    shellExtraArgs = ['-t', ...remoteHosts.controlArgs(sock), ...remoteHosts.hostTargetArgs(remoteHost)];
+    isWsl = false;
+    log.info(`[shell] remote host=${remoteHost.id} shell=ssh args=${JSON.stringify(shellExtraArgs)}`);
+  } else {
+    // Resolve shell profile from effective settings
+    const effectiveProfileId = (() => {
+      const global = getSetting('global') || {};
+      const project = projectPath ? (getSetting('project:' + projectPath) || {}) : {};
+      let profileId = SETTING_DEFAULTS.shellProfile;
+      if (global.shellProfile !== undefined && global.shellProfile !== null) profileId = global.shellProfile;
+      if (project.shellProfile !== undefined && project.shellProfile !== null) profileId = project.shellProfile;
+      return profileId;
+    })();
+    // WSL profiles only work for plain terminals — Claude CLI sessions need the
+    // Windows shell because session data lives on the Windows filesystem.
+    const requestedProfile = resolveShell(effectiveProfileId);
+    const shellProfile = (isWslShell(requestedProfile.path) && !isPlainTerminal)
+      ? resolveShell('auto')
+      : requestedProfile;
+    shell = shellProfile.path;
+    shellExtraArgs = [...(shellProfile.args || [])];
+    isWsl = isWslShell(shell);
+    // For WSL, convert Windows path to /mnt/ path and pass via --cd;
+    // the spawn cwd must remain a valid Windows path for wsl.exe itself.
+    if (isWsl) {
+      const wslCwd = windowsToWslPath(projectPath);
+      shellExtraArgs.unshift('--cd', wslCwd);
+    }
+    log.info(`[shell] profile=${shellProfile.id} shell=${shell} args=${JSON.stringify(shellExtraArgs)}`);
   }
-  log.info(`[shell] profile=${shellProfile.id} shell=${shell} args=${JSON.stringify(shellExtraArgs)}`);
 
   let knownJsonlFiles = new Set();
   let sessionSlug = null;
   let projectFolder = null;
 
-  if (!isPlainTerminal) {
+  if (!isPlainTerminal && !isRemote) {
     // Snapshot existing .jsonl files before spawning (for new session + fork/plan detection)
     projectFolder = encodeProjectPath(projectPath);
     const claudeProjectDir = path.join(PROJECTS_DIR, projectFolder);
@@ -1009,7 +1232,40 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
   let ptyProcess;
   let mcpServer = null;
   try {
-    if (isPlainTerminal) {
+    if (isRemote) {
+      // Remote (SSH) session: run Claude (or a login shell) on the remote host.
+      // No claude shim and no IDE/MCP emulation — the MCP socket is local and
+      // the CLI on the remote can't reach it (IDE over SSH is a later phase).
+      const remoteMode = sessionOptions?.remoteMode === 'shell' ? 'shell' : 'claude';
+      let innerCmd = null;
+      if (remoteMode === 'claude') {
+        // Phase 1 launches a fresh remote Claude session; --session-id/--resume
+        // are managed on the remote host and wired up in a later milestone.
+        let cc = 'claude';
+        if (sessionOptions?.dangerouslySkipPermissions) {
+          cc += ' --dangerously-skip-permissions';
+        } else if (sessionOptions?.permissionMode) {
+          cc += ` --permission-mode "${sessionOptions.permissionMode}"`;
+        }
+        if (sessionOptions?.addDirs) {
+          const dirs = sessionOptions.addDirs.split(',').map(d => d.trim()).filter(Boolean);
+          for (const dir of dirs) cc += ` --add-dir "${dir}"`;
+        }
+        innerCmd = cc;
+      }
+      const remoteCmd = remoteHosts.buildRemoteCommand(remoteMode, sessionOptions?.remoteDir || '~', innerCmd);
+      ptyProcess = pty.spawn(shell, shellArgs(shell, remoteCmd, shellExtraArgs), {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 30,
+        cwd: os.homedir(), // local cwd; the remote cd happens inside remoteCmd
+        env: {
+          ...cleanPtyEnv,
+          TERM: 'xterm-256color', COLORTERM: 'truecolor',
+          TERM_PROGRAM: 'iTerm.app', TERM_PROGRAM_VERSION: '3.6.6', FORCE_COLOR: '3', ITERM_SESSION_ID: '1',
+        },
+      });
+    } else if (isPlainTerminal) {
       // Plain terminal: interactive login shell, no claude command
       // Inject a shell function to override `claude` with a helpful message
       const claudeShim = 'claude() { echo "\\033[33mTo start a Claude session, use the + button in the sidebar.\\033[0m"; return 1; }; export -f claude 2>/dev/null;';
@@ -1121,7 +1377,12 @@ ipcMain.handle('open-terminal', async (_event, sessionId, projectPath, isNew, se
     outputBuffer: [], outputBufferSize: 0, altScreen: false,
     projectPath, firstResize: true,
     projectFolder, knownJsonlFiles, sessionSlug,
-    isPlainTerminal, forkFrom: sessionOptions?.forkFrom || null,
+    // Remote sessions are treated as live "terminal" entries so they flow through
+    // the sidebar's active-session injection (no local .jsonl indexing yet).
+    isPlainTerminal: isPlainTerminal || isRemote,
+    remote: isRemote, remoteHost: remoteHost || null,
+    remoteMode: isRemote ? (sessionOptions?.remoteMode === 'shell' ? 'shell' : 'claude') : null,
+    forkFrom: sessionOptions?.forkFrom || null,
     mcpServer, _openedAt: Date.now(),
   };
   activeSessions.set(sessionId, session);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "main.js",
   "scripts": {
     "start": "npm run bundle:codemirror && electron .",
-    "test": "node --test",
+    "test": "ELECTRON_RUN_AS_NODE=1 electron --test",
     "electron": "electron .",
     "bundle:codemirror": "esbuild public/codemirror-setup.js --bundle --outfile=public/codemirror-bundle.js --format=iife --platform=browser --minify",
     "generate-icons": "node scripts/generate-icons.js && node scripts/generate-dmg-background.js",

--- a/preload.js
+++ b/preload.js
@@ -32,6 +32,19 @@ contextBridge.exposeInMainWorld('api', {
   runScheduleNow: (filePath) => ipcRenderer.invoke('run-schedule-now', filePath),
   getShellProfiles: () => ipcRenderer.invoke('get-shell-profiles'),
 
+  // Remote SSH hosts + projects
+  getRemoteTargets: () => ipcRenderer.invoke('get-remote-targets'),
+  saveRemoteHosts: (hosts) => ipcRenderer.invoke('save-remote-hosts', hosts),
+  testRemoteHost: (hostId) => ipcRenderer.invoke('test-remote-host', hostId),
+  addRemoteProject: (opts) => ipcRenderer.invoke('add-remote-project', opts),
+  remoteBrowse: (opts) => ipcRenderer.invoke('remote-browse', opts),
+  writeSshConfig: (host) => ipcRenderer.invoke('write-ssh-config', host),
+  remoteConnectStart: (hostId) => ipcRenderer.invoke('remote-connect-start', hostId),
+  remoteConnectInput: (connectId, data) => ipcRenderer.send('remote-connect-input', connectId, data),
+  remoteConnectCancel: (connectId) => ipcRenderer.invoke('remote-connect-cancel', connectId),
+  onRemoteConnectData: (callback) => ipcRenderer.on('remote-connect-data', (_e, id, data) => callback(id, data)),
+  onRemoteConnectExit: (callback) => ipcRenderer.on('remote-connect-exit', (_e, id, code) => callback(id, code)),
+
   browseFolder: () => ipcRenderer.invoke('browse-folder'),
   addProject: (projectPath) => ipcRenderer.invoke('add-project', projectPath),
   removeProject: (projectPath) => ipcRenderer.invoke('remove-project', projectPath),

--- a/preload.js
+++ b/preload.js
@@ -37,6 +37,7 @@ contextBridge.exposeInMainWorld('api', {
   saveRemoteHosts: (hosts) => ipcRenderer.invoke('save-remote-hosts', hosts),
   testRemoteHost: (hostId) => ipcRenderer.invoke('test-remote-host', hostId),
   addRemoteProject: (opts) => ipcRenderer.invoke('add-remote-project', opts),
+  syncRemoteHost: (hostId) => ipcRenderer.invoke('sync-remote-host', hostId),
   remoteBrowse: (opts) => ipcRenderer.invoke('remote-browse', opts),
   writeSshConfig: (host) => ipcRenderer.invoke('write-ssh-config', host),
   remoteConnectStart: (hostId) => ipcRenderer.invoke('remote-connect-start', hostId),

--- a/public/app.js
+++ b/public/app.js
@@ -788,11 +788,32 @@ async function openSession(session, customOptions) {
     }
   }
 
+  // Remote past session: resume it in a terminal on the host — same UI and
+  // behavior as clicking a local session (which auto-resumes via `claude --resume`).
+  let remoteResumeOptions = null;
+  if (session.remote && session.remoteMode !== 'shell') {
+    // Derive the remote dir from the ssh://<label>/<dir> projectPath (always
+    // present) so resume lands in the session's own directory even if the
+    // session object is missing remotePath.
+    let remoteDir = session.remotePath;
+    if (!remoteDir && typeof projectPath === 'string' && projectPath.startsWith('ssh://')) {
+      const rest = projectPath.slice('ssh://'.length);
+      const slash = rest.indexOf('/');
+      remoteDir = slash === -1 ? '~' : (rest.slice(slash + 1) || '~');
+    }
+    remoteResumeOptions = {
+      remoteHostId: session.hostId || session.source,
+      remoteMode: 'claude',
+      remoteDir: remoteDir || '~',
+      resume: sessionId,
+    };
+  }
+
   // Create new terminal entry (hidden until showSession)
   const entry = createTerminalEntry(session);
 
   // Open terminal in main process
-  const resumeOptions = customOptions || await resolveDefaultSessionOptions({ projectPath });
+  const resumeOptions = customOptions || remoteResumeOptions || await resolveDefaultSessionOptions({ projectPath });
   const result = await window.api.openTerminal(sessionId, projectPath, false, resumeOptions);
   if (!result.ok) {
     entry.terminal.write(`\r\nError: ${result.error}\r\n`);

--- a/public/dialogs.js
+++ b/public/dialogs.js
@@ -98,11 +98,38 @@ function showNewSessionPopover(project, anchorEl) {
   termBtn.innerHTML = '<svg class="popover-option-icon terminal-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg> Terminal';
   termBtn.onclick = () => { popover.remove(); launchTerminalSession(project); };
 
+  // Remote project: reuse the exact same icons as the local entries (identical
+  // Claude logo), just labeled/wired for running on the project's SSH host.
+  if (project.remote) {
+    const rHost = { id: project.hostId, label: project.hostLabel };
+    const claudeR = document.createElement('button');
+    claudeR.className = 'popover-option';
+    claudeR.innerHTML = claudeBtn.innerHTML.replace('</svg> Claude', '</svg> Claude (remote)');
+    claudeR.onclick = () => { popover.remove(); launchRemoteSession(rHost, { remoteMode: 'claude', remoteDir: project.remotePath }); };
+    const claudeROpts = document.createElement('button');
+    claudeROpts.className = 'popover-option';
+    claudeROpts.innerHTML = claudeBtn.innerHTML.replace('</svg> Claude', '</svg> Claude (remote, Configure…)');
+    claudeROpts.onclick = () => { popover.remove(); showNewSessionDialog(project); };
+    const shellR = document.createElement('button');
+    shellR.className = 'popover-option popover-option-terminal';
+    shellR.innerHTML = termBtn.innerHTML.replace('</svg> Terminal', '</svg> Shell (remote)');
+    shellR.onclick = () => { popover.remove(); launchRemoteSession(rHost, { remoteMode: 'shell', remoteDir: project.remotePath }); };
+    popover.appendChild(claudeR);
+    popover.appendChild(claudeROpts);
+    popover.appendChild(shellR);
+    positionAndBindPopover(popover, anchorEl);
+    return;
+  }
+
   popover.appendChild(claudeBtn);
   popover.appendChild(claudeOptsBtn);
   popover.appendChild(termBtn);
 
-  // Position relative to anchor, flip upward if it would overflow
+  positionAndBindPopover(popover, anchorEl);
+}
+
+// Position a popover under its anchor (flip up on overflow) and close on outside click.
+function positionAndBindPopover(popover, anchorEl) {
   document.body.appendChild(popover);
   const rect = anchorEl.getBoundingClientRect();
   const popoverHeight = popover.offsetHeight;
@@ -113,7 +140,6 @@ function showNewSessionPopover(project, anchorEl) {
   }
   popover.style.left = rect.left + 'px';
 
-  // Close on click outside
   function onClickOutside(e) {
     if (!popover.contains(e.target) && e.target !== anchorEl) {
       popover.remove();
@@ -169,8 +195,71 @@ async function launchTerminalSession(project) {
   pollActiveSessions();
 }
 
+// Launch a session on a remote host over SSH. Modeled on launchTerminalSession:
+// remote sessions are live "terminal" entries with a synthetic ssh:// project
+// path so they group in the sidebar (no local .jsonl indexing in Phase 1).
+async function launchRemoteSession(host, opts) {
+  const options = opts || {};
+  const remoteDir = options.remoteDir || '~';
+  const mode = options.remoteMode === 'shell' ? 'shell' : 'claude';
+  const sessionId = crypto.randomUUID();
+  const projectPath = `ssh://${host.label}/${remoteDir}`;
+  const summary = (mode === 'shell' ? 'Shell @ ' : 'Claude @ ') + host.label;
+  const session = {
+    sessionId,
+    summary,
+    firstPrompt: '',
+    projectPath,
+    name: null,
+    starred: 0,
+    archived: 0,
+    messageCount: 0,
+    modified: new Date().toISOString(),
+    created: new Date().toISOString(),
+    type: 'terminal',
+    remote: true,
+    remoteLabel: host.label,
+    remoteMode: mode,
+  };
+
+  const folder = encodeProjectPath(projectPath);
+  pendingSessions.set(sessionId, { session, projectPath, folder });
+
+  sessionMap.set(sessionId, session);
+  for (const projList of [cachedProjects, cachedAllProjects]) {
+    let proj = projList.find(p => p.projectPath === projectPath);
+    if (!proj) {
+      proj = { folder, projectPath, sessions: [] };
+      projList.unshift(proj);
+    }
+    proj.sessions.unshift(session);
+  }
+  refreshSidebar();
+
+  const entry = createTerminalEntry(session);
+
+  const result = await window.api.openTerminal(sessionId, projectPath, true, {
+    type: 'terminal',
+    remoteHostId: host.id,
+    remoteMode: mode,
+    remoteDir,
+    dangerouslySkipPermissions: options.dangerouslySkipPermissions,
+    permissionMode: options.permissionMode,
+    addDirs: options.addDirs,
+  });
+  if (!result.ok) {
+    entry.terminal.write(`\r\nError: ${result.error}\r\n`);
+    entry.closed = true;
+    return;
+  }
+
+  showSession(sessionId);
+  pollActiveSessions();
+}
+
 async function showNewSessionDialog(project) {
   const effective = await window.api.getEffectiveSettings(project.projectPath);
+  const isRemote = !!project.remote; // Model A: the project itself is local or remote
 
   const overlay = document.createElement('div');
   overlay.className = 'new-session-overlay';
@@ -197,38 +286,54 @@ async function showNewSessionDialog(project) {
     `<button class="permission-option dangerous${dangerousSkip ? ' selected' : ''}" data-mode="dangerous-skip"><span class="perm-name">Dangerous Skip</span><span class="perm-desc">Skip all safety prompts (use with caution)</span></button>`;
   }
 
+  const titleText = isRemote
+    ? `New Remote Session — ${escapeHtml(project.hostLabel)} : ${escapeHtml(project.remotePath || '~')}`
+    : `New Session — ${escapeHtml(project.projectPath.split('/').filter(Boolean).slice(-2).join('/'))}`;
+
   dialog.innerHTML = `
-    <h3>New Session — ${escapeHtml(project.projectPath.split('/').filter(Boolean).slice(-2).join('/'))}</h3>
+    <h3>${titleText}</h3>
+    <div class="settings-field settings-field-wide" id="nsd-remote-dir-field" style="display:${isRemote ? '' : 'none'}">
+      <div class="settings-field-info">
+        <span class="settings-label">Remote Directory</span>
+        <div class="settings-description">Working directory on the remote host</div>
+      </div>
+      <div class="settings-field-control folder-input-row">
+        <input type="text" class="settings-input" id="nsd-remote-dir" placeholder="~/path/to/project" value="${escapeHtml(project.remotePath || '~')}">
+        <button class="add-project-browse-btn" id="nsd-remote-browse" type="button">Browse</button>
+      </div>
+    </div>
     <div class="settings-field">
       <div class="settings-label">Permission Mode</div>
       <div class="permission-grid" id="nsd-mode-grid">${renderModeGrid()}</div>
     </div>
-    <div class="settings-field">
-      <div class="settings-field-info">
-        <span class="settings-label">Worktree</span>
-        <div class="settings-description">Run session in an isolated git worktree</div>
+    <div id="nsd-local-only">
+      <div class="settings-field">
+        <div class="settings-field-info">
+          <span class="settings-label">Worktree</span>
+          <div class="settings-description">Run session in an isolated git worktree</div>
+        </div>
+        <div class="settings-field-control">
+          <input type="text" class="settings-input" id="nsd-worktree-name" placeholder="name (optional)" value="${escapeHtml(effective.worktreeName || '')}" style="width:140px">
+          <label class="settings-toggle"><input type="checkbox" id="nsd-worktree" ${effective.worktree ? 'checked' : ''}><span class="settings-toggle-slider"></span></label>
+        </div>
       </div>
-      <div class="settings-field-control">
-        <input type="text" class="settings-input" id="nsd-worktree-name" placeholder="name (optional)" value="${escapeHtml(effective.worktreeName || '')}" style="width:140px">
-        <label class="settings-toggle"><input type="checkbox" id="nsd-worktree" ${effective.worktree ? 'checked' : ''}><span class="settings-toggle-slider"></span></label>
+      <div class="settings-field">
+        <div class="settings-field-info">
+          <span class="settings-label">Chrome</span>
+          <div class="settings-description">Enable Chrome browser automation</div>
+        </div>
+        <div class="settings-field-control">
+          <label class="settings-toggle"><input type="checkbox" id="nsd-chrome" ${effective.chrome ? 'checked' : ''}><span class="settings-toggle-slider"></span></label>
+        </div>
       </div>
-    </div>
-    <div class="settings-field">
-      <div class="settings-field-info">
-        <span class="settings-label">Chrome</span>
-        <div class="settings-description">Enable Chrome browser automation</div>
-      </div>
-      <div class="settings-field-control">
-        <label class="settings-toggle"><input type="checkbox" id="nsd-chrome" ${effective.chrome ? 'checked' : ''}><span class="settings-toggle-slider"></span></label>
-      </div>
-    </div>
-    <div class="settings-field settings-field-wide">
-      <div class="settings-field-info">
-        <span class="settings-label">Pre-launch Command</span>
-        <div class="settings-description">Prepended to the claude command</div>
-      </div>
-      <div class="settings-field-control">
-        <input type="text" class="settings-input" id="nsd-pre-launch" placeholder="e.g. aws-vault exec profile --" value="${escapeHtml(effective.preLaunchCmd || '')}">
+      <div class="settings-field settings-field-wide">
+        <div class="settings-field-info">
+          <span class="settings-label">Pre-launch Command</span>
+          <div class="settings-description">Prepended to the claude command</div>
+        </div>
+        <div class="settings-field-control">
+          <input type="text" class="settings-input" id="nsd-pre-launch" placeholder="e.g. aws-vault exec profile --" value="${escapeHtml(effective.preLaunchCmd || '')}">
+        </div>
       </div>
     </div>
     <div class="settings-field settings-field-wide">
@@ -242,6 +347,7 @@ async function showNewSessionDialog(project) {
     </div>
     <div class="new-session-actions">
       <button class="new-session-cancel-btn">Cancel</button>
+      <button class="new-session-shell-btn" style="display:none">Open shell</button>
       <button class="new-session-start-btn">Start</button>
     </div>
   `;
@@ -269,13 +375,43 @@ async function showNewSessionDialog(project) {
     overlay.remove();
   }
 
-  function start() {
+  // Model A: local vs remote is fixed by the project. Show the matching controls.
+  const localOnly = dialog.querySelector('#nsd-local-only');
+  const shellBtn = dialog.querySelector('.new-session-shell-btn');
+  const startBtn = dialog.querySelector('.new-session-start-btn');
+  if (localOnly) localOnly.style.display = isRemote ? 'none' : '';
+  shellBtn.style.display = isRemote ? '' : 'none';
+  startBtn.textContent = isRemote ? 'Start Claude' : 'Start';
+
+  if (isRemote) {
+    const rbBtn = dialog.querySelector('#nsd-remote-browse');
+    if (rbBtn) rbBtn.onclick = async () => {
+      const inp = dialog.querySelector('#nsd-remote-dir');
+      const picked = await showRemoteDirBrowser({ id: project.hostId, label: project.hostLabel }, inp.value.trim() || '~');
+      if (picked) inp.value = picked;
+    };
+  }
+
+  function permissionOptions() {
     const options = {};
-    if (dangerousSkip) {
-      options.dangerouslySkipPermissions = true;
-    } else if (selectedMode) {
-      options.permissionMode = selectedMode;
+    if (dangerousSkip) options.dangerouslySkipPermissions = true;
+    else if (selectedMode) options.permissionMode = selectedMode;
+    options.addDirs = dialog.querySelector('#nsd-add-dirs').value.trim();
+    return options;
+  }
+
+  function remoteDirValue() {
+    return dialog.querySelector('#nsd-remote-dir').value.trim() || project.remotePath || '~';
+  }
+
+  function start() {
+    if (isRemote) {
+      const options = { ...permissionOptions(), remoteMode: 'claude', remoteDir: remoteDirValue() };
+      close();
+      launchRemoteSession({ id: project.hostId, label: project.hostLabel }, options);
+      return;
     }
+    const options = permissionOptions();
     if (dialog.querySelector('#nsd-worktree').checked) {
       options.worktree = true;
       options.worktreeName = dialog.querySelector('#nsd-worktree-name').value.trim();
@@ -285,14 +421,21 @@ async function showNewSessionDialog(project) {
     }
     const preLaunch = dialog.querySelector('#nsd-pre-launch').value.trim();
     if (preLaunch) options.preLaunchCmd = preLaunch;
-    options.addDirs = dialog.querySelector('#nsd-add-dirs').value.trim();
     if (effective.mcpEmulation === false) options.mcpEmulation = false;
     close();
     launchNewSession(project, options);
   }
 
+  function openShell() {
+    if (!isRemote) return;
+    const options = { remoteMode: 'shell', remoteDir: remoteDirValue() };
+    close();
+    launchRemoteSession({ id: project.hostId, label: project.hostLabel }, options);
+  }
+
   dialog.querySelector('.new-session-cancel-btn').onclick = close;
-  dialog.querySelector('.new-session-start-btn').onclick = start;
+  startBtn.onclick = start;
+  shellBtn.onclick = openShell;
   overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
 
   // Keyboard support
@@ -427,19 +570,367 @@ async function showResumeSessionDialog(session) {
 // Settings viewer is in settings-panel.js (openSettingsViewer / closeSettingsViewer)
 // Global settings button & add project button bindings are in app.js (need DOM refs)
 
-function showAddProjectDialog() {
+// Dedicated interactive-connect channel. One connect runs at a time; the module
+// listeners route events to the active handler set by connectRemoteHost().
+let _rcData = null, _rcExit = null;
+if (window.api && window.api.onRemoteConnectData) window.api.onRemoteConnectData((id, data) => { if (_rcData) _rcData(id, data); });
+if (window.api && window.api.onRemoteConnectExit) window.api.onRemoteConnectExit((id, code) => { if (_rcExit) _rcExit(id, code); });
+
+// Structured auth prompt. Presents the right UI for what ssh is asking:
+//  - hostkey  → fingerprint text + Yes/No
+//  - password/passphrase → masked input field
+//  - otp/generic → text field
+// Resolves to the string to send (for hostkey: 'yes'), or null if cancelled.
+function showAuthPrompt(host, p) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'new-session-overlay remote-browser-overlay';
+    const d = document.createElement('div');
+    d.className = 'new-session-dialog';
+    const titles = { password: 'Password', passphrase: 'Key passphrase', otp: 'Verification code', hostkey: 'Verify host key', generic: 'Input required' };
+    const title = titles[p.kind] || 'Input required';
+    const done = (v) => { overlay.remove(); document.removeEventListener('keydown', onKey); resolve(v); };
+    function onKey(e) { if (e.key === 'Escape') done(null); }
+
+    if (p.kind === 'hostkey') {
+      d.innerHTML = `
+        <h3>${title} — ${escapeHtml(host.label || host.id)}</h3>
+        <div class="remote-connect-hint">First time connecting to this host. Confirm the fingerprint to continue.</div>
+        <pre class="auth-fingerprint">${escapeHtml(p.text || '')}</pre>
+        <div class="new-session-actions">
+          <button class="new-session-cancel-btn" id="ap-no">No</button>
+          <button class="new-session-start-btn" id="ap-yes">Yes, connect</button>
+        </div>`;
+      overlay.appendChild(d); document.body.appendChild(overlay);
+      document.addEventListener('keydown', onKey);
+      overlay.addEventListener('click', (e) => { if (e.target === overlay) done(null); });
+      d.querySelector('#ap-yes').onclick = () => done('yes');
+      d.querySelector('#ap-no').onclick = () => done(null);
+      return;
+    }
+
+    const masked = (p.kind === 'password' || p.kind === 'passphrase');
+    d.innerHTML = `
+      <h3>${title} — ${escapeHtml(host.label || host.id)}</h3>
+      <div class="remote-connect-hint">${escapeHtml(p.text || (title + ':'))}</div>
+      <div class="settings-field"><div class="settings-field-control">
+        <input class="settings-input" id="ap-input" type="${masked ? 'password' : 'text'}" autocomplete="off" spellcheck="false" style="width:100%">
+      </div></div>
+      <div class="new-session-actions">
+        <button class="new-session-cancel-btn" id="ap-cancel">Cancel</button>
+        <button class="new-session-start-btn" id="ap-ok">OK</button>
+      </div>`;
+    overlay.appendChild(d); document.body.appendChild(overlay);
+    const inp = d.querySelector('#ap-input');
+    inp.focus();
+    // Submit sends the value to ssh, then clears it from the field immediately.
+    const submit = () => { const v = inp.value; inp.value = ''; done(v); };
+    document.addEventListener('keydown', onKey);
+    inp.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); submit(); } });
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) done(null); });
+    d.querySelector('#ap-ok').onclick = submit;
+    d.querySelector('#ap-cancel').onclick = () => done(null);
+  });
+}
+
+// Verify/authenticate a host inline (no sidebar session). Resolves true once the
+// connection is established (and warmed via ControlMaster). ssh's prompts are
+// surfaced as structured popups (password field / Yes-No fingerprint) — never a
+// raw terminal. Key/agent hosts connect silently with no popup.
+function connectRemoteHost(host) {
+  return new Promise((resolve) => {
+    let connectId = null, buffer = '', settled = false, promptOpen = false, errModal = null;
+
+    function finish(val) {
+      if (settled) return;
+      settled = true; _rcData = null; _rcExit = null;
+      if (errModal) { errModal.remove(); errModal = null; }
+      resolve(val);
+    }
+
+    // Detect what ssh is waiting for. Only when the buffer ends WITHOUT a newline
+    // (cursor parked at a prompt), which avoids matching normal banner lines.
+    function detectPrompt(buf) {
+      const tail = buf.slice(-1000);
+      if (/\n[ \t]*$/.test(tail)) return null; // ends with newline → not a waiting prompt
+      if (/(authenticity of host|continue connecting \(yes\/no)/i.test(tail) && /\?[ \t]*$/.test(tail)) {
+        const m = tail.match(/The authenticity of host[\s\S]*\?[ \t]*$/i);
+        return { kind: 'hostkey', text: (m ? m[0] : tail).trim() };
+      }
+      if (/enter passphrase for key[^\n]*:[ \t]*$/i.test(tail)) return { kind: 'passphrase', text: tail.split('\n').pop().trim() };
+      if (/password:[ \t]*$/i.test(tail)) return { kind: 'password', text: tail.split('\n').pop().trim() };
+      if (/(verification code|one-time|two-factor|token|otp)[^\n]*:[ \t]*$/i.test(tail)) return { kind: 'otp', text: tail.split('\n').pop().trim() };
+      if (/[:?][ \t]*$/.test(tail)) {
+        const line = tail.split('\n').pop().trim();
+        if (line.length > 1 && line.length < 200) return { kind: 'generic', text: line };
+      }
+      return null;
+    }
+
+    async function handlePrompt(p) {
+      promptOpen = true;
+      const ans = await showAuthPrompt(host, p);
+      promptOpen = false;
+      if (ans === null) { if (connectId != null) window.api.remoteConnectCancel(connectId); finish(false); return; }
+      buffer = '';
+      if (connectId != null) window.api.remoteConnectInput(connectId, ans + '\n');
+    }
+
+    function showError(msg) {
+      if (settled) return;
+      if (errModal) errModal.remove();
+      errModal = document.createElement('div');
+      errModal.className = 'new-session-overlay remote-browser-overlay';
+      const d = document.createElement('div');
+      d.className = 'new-session-dialog';
+      d.innerHTML = `
+        <h3>Connect — ${escapeHtml(host.label || host.id)}</h3>
+        <div class="remote-connect-msg err" style="margin-bottom:12px">${escapeHtml(msg)}</div>
+        <div class="new-session-actions">
+          <button class="new-session-cancel-btn" id="ce-cancel">Cancel</button>
+          <button class="new-session-start-btn" id="ce-retry">Retry</button>
+        </div>`;
+      errModal.appendChild(d); document.body.appendChild(errModal);
+      d.querySelector('#ce-cancel').onclick = () => finish(false);
+      d.querySelector('#ce-retry').onclick = () => { errModal.remove(); errModal = null; start(); };
+    }
+
+    async function start() {
+      buffer = '';
+      const res = await window.api.remoteConnectStart(host.id);
+      if (!res || res.error) { showError((res && res.error) || 'Could not start ssh.'); return; }
+      connectId = res.connectId;
+      _rcData = (id, data) => {
+        if (id !== connectId) return;
+        buffer += data; if (buffer.length > 8000) buffer = buffer.slice(-8000);
+        if (promptOpen) return;
+        const p = detectPrompt(buffer);
+        if (p) handlePrompt(p);
+      };
+      _rcExit = (id, code) => {
+        if (id !== connectId) return;
+        _rcData = null; _rcExit = null;
+        if (code === 0) finish(true);
+        else {
+          const lastLine = buffer.split('\n').map(s => s.trim()).filter(Boolean).slice(-1)[0] || '';
+          showError('Connection failed' + (lastLine ? ': ' + lastLine : ' (exit ' + code + ').'));
+        }
+      };
+    }
+
+    start();
+  });
+}
+
+// Remote directory browser: navigate the remote filesystem over SSH and pick a
+// directory (like the local folder Browse). Resolves to the chosen path or null.
+function showRemoteDirBrowser(host, startPath) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'new-session-overlay remote-browser-overlay';
+    const dialog = document.createElement('div');
+    dialog.className = 'new-session-dialog remote-browser-dialog';
+    dialog.innerHTML = `
+      <h3>Browse — ${escapeHtml(host.label || host.id)}</h3>
+      <div class="folder-input-row">
+        <input type="text" class="settings-input" id="rb-path" value="${escapeHtml(startPath || '~')}" autocomplete="off" spellcheck="false">
+        <button class="add-project-browse-btn" id="rb-go">Go</button>
+      </div>
+      <div class="remote-browser-list" id="rb-list"></div>
+      <div class="remote-browser-msg" id="rb-msg"></div>
+      <div class="new-session-actions">
+        <button class="new-session-cancel-btn" id="rb-cancel">Cancel</button>
+        <button class="new-session-start-btn" id="rb-select">Select this directory</button>
+      </div>`;
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    const pathInput = dialog.querySelector('#rb-path');
+    const listEl = dialog.querySelector('#rb-list');
+    const msgEl = dialog.querySelector('#rb-msg');
+    let current = startPath || '~';
+
+    function close(val) { overlay.remove(); document.removeEventListener('keydown', onKey); resolve(val); }
+    function onKey(e) { if (e.key === 'Escape') close(null); }
+    document.addEventListener('keydown', onKey);
+
+    function joinPath(base, name) { return base === '~' ? '~/' + name : base.replace(/\/+$/, '') + '/' + name; }
+    function parentPath(p) {
+      if (p === '~' || p === '/') return p;
+      const t = p.replace(/\/+$/, '');
+      const i = t.lastIndexOf('/');
+      if (i <= 0) return p.startsWith('/') ? '/' : '~';
+      const par = t.slice(0, i);
+      return par === '~' ? '~' : (par || '/');
+    }
+
+    async function load(path) {
+      current = path;
+      pathInput.value = path;
+      msgEl.textContent = '';
+      listEl.innerHTML = '<div class="remote-browser-status">Loading…</div>';
+      let res;
+      try { res = await window.api.remoteBrowse({ hostId: host.id, path }); }
+      catch (e) { listEl.innerHTML = ''; msgEl.textContent = 'Error: ' + e.message; return; }
+      listEl.innerHTML = '';
+      if (!res.ok) {
+        if (res.needsAuth) {
+          msgEl.textContent = 'This host needs interactive login. Open a session to it once to authenticate, then try Browse again — or just type the path.';
+        } else {
+          msgEl.textContent = res.message || res.error || 'Could not list this directory.';
+        }
+        return;
+      }
+      const up = document.createElement('div');
+      up.className = 'remote-browser-item remote-browser-up';
+      up.textContent = '📂 ..';
+      up.onclick = () => load(parentPath(current));
+      listEl.appendChild(up);
+      for (const d of res.dirs) {
+        const it = document.createElement('div');
+        it.className = 'remote-browser-item';
+        it.textContent = '📁 ' + d;
+        it.onclick = () => load(joinPath(current, d));
+        listEl.appendChild(it);
+      }
+      if (!res.dirs.length) {
+        const e = document.createElement('div');
+        e.className = 'remote-browser-status';
+        e.textContent = '(no subdirectories)';
+        listEl.appendChild(e);
+      }
+    }
+
+    dialog.querySelector('#rb-go').onclick = () => load(pathInput.value.trim() || '~');
+    pathInput.addEventListener('keydown', e => { if (e.key === 'Enter') { e.stopPropagation(); load(pathInput.value.trim() || '~'); } });
+    dialog.querySelector('#rb-cancel').onclick = () => close(null);
+    dialog.querySelector('#rb-select').onclick = () => close(pathInput.value.trim() || current);
+    overlay.addEventListener('click', e => { if (e.target === overlay) close(null); });
+
+    load(current);
+  });
+}
+
+// Inline "add SSH host" form. Persists the new host into settings (merged with
+// existing manual hosts) and resolves to the saved host ({id,label,…}) or null.
+function showAddHostDialog() {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'new-session-overlay remote-browser-overlay';
+    const d = document.createElement('div');
+    d.className = 'new-session-dialog';
+    d.innerHTML = `
+      <h3>Add SSH Host</h3>
+      <div class="settings-field"><div class="settings-field-info"><span class="settings-label">Label</span></div><div class="settings-field-control"><input class="settings-input" id="ah-label" placeholder="my-server (optional)"></div></div>
+      <div class="settings-field"><div class="settings-field-info"><span class="settings-label">User</span></div><div class="settings-field-control"><input class="settings-input" id="ah-user" placeholder="user (optional)"></div></div>
+      <div class="settings-field"><div class="settings-field-info"><span class="settings-label">Host</span></div><div class="settings-field-control"><input class="settings-input" id="ah-host" placeholder="hostname or IP"></div></div>
+      <div class="settings-field"><div class="settings-field-info"><span class="settings-label">Port</span></div><div class="settings-field-control"><input class="settings-input" id="ah-port" placeholder="22"></div></div>
+      <div class="settings-field"><div class="settings-field-info"><span class="settings-label">Identity file</span></div><div class="settings-field-control"><input class="settings-input" id="ah-identity" placeholder="~/.ssh/id_ed25519 (optional)"></div></div>
+      <div class="settings-field">
+        <div class="settings-field-info">
+          <span class="settings-label">Extra options</span>
+          <div class="settings-description">Extra <code>ssh -o</code> options for legacy/special hosts — leave blank for most. Click to add:</div>
+          <div class="ah-opt-chips">
+            <button type="button" class="ah-chip" data-opt="HostKeyAlgorithms=+ssh-rsa">HostKeyAlgorithms=+ssh-rsa</button>
+            <button type="button" class="ah-chip" data-opt="PubkeyAcceptedKeyTypes=+ssh-rsa">PubkeyAcceptedKeyTypes=+ssh-rsa</button>
+            <button type="button" class="ah-chip" data-opt="PreferredAuthentications=password">PreferredAuthentications=password</button>
+            <button type="button" class="ah-chip" data-opt="ProxyJump=bastion">ProxyJump=bastion</button>
+            <button type="button" class="ah-chip" data-opt="ServerAliveInterval=30">ServerAliveInterval=30</button>
+          </div>
+        </div>
+        <div class="settings-field-control"><input class="settings-input" id="ah-options" placeholder="comma-separated Key=Value (optional)"></div>
+      </div>
+      <div class="remote-connect-msg" id="ah-err"></div>
+      <div class="new-session-actions">
+        <button class="new-session-cancel-btn" id="ah-cancel">Cancel</button>
+        <button class="new-session-start-btn" id="ah-save">Save host</button>
+      </div>`;
+    overlay.appendChild(d);
+    document.body.appendChild(overlay);
+    d.querySelector('#ah-host').focus();
+
+    function close(v) { overlay.remove(); document.removeEventListener('keydown', onKey); resolve(v); }
+    function onKey(e) { if (e.key === 'Escape') close(null); }
+    document.addEventListener('keydown', onKey);
+    const setErr = (m) => { const e = d.querySelector('#ah-err'); e.textContent = m; e.className = 'remote-connect-msg err'; };
+
+    d.querySelector('#ah-cancel').onclick = () => close(null);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(null); });
+    // Example-option chips: click to append (deduped) into the options field.
+    d.querySelectorAll('.ah-chip').forEach(chip => {
+      chip.onclick = () => {
+        const inp = d.querySelector('#ah-options');
+        const parts = inp.value.split(',').map(s => s.trim()).filter(Boolean);
+        if (!parts.includes(chip.dataset.opt)) parts.push(chip.dataset.opt);
+        inp.value = parts.join(', ');
+      };
+    });
+    d.querySelector('#ah-save').onclick = async () => {
+      const host = d.querySelector('#ah-host').value.trim();
+      if (!host) { setErr('Host is required.'); return; }
+      const newHost = {
+        label: d.querySelector('#ah-label').value.trim(),
+        user: d.querySelector('#ah-user').value.trim(),
+        host,
+        port: d.querySelector('#ah-port').value.trim(),
+        identityFile: d.querySelector('#ah-identity').value.trim(),
+        options: d.querySelector('#ah-options').value.trim(),
+      };
+      let existing = [];
+      try { existing = (await window.api.getRemoteTargets()).filter(h => h.source === 'manual'); } catch {}
+      const res = await window.api.saveRemoteHosts([...existing, newHost]);
+      if (!res || !res.ok) { setErr('Failed to save host.'); return; }
+      const saved = (res.hosts || []).find(h => h.source === 'manual' && h.host === host && (h.user || '') === (newHost.user || '')) || null;
+      close(saved);
+    };
+  });
+}
+
+async function showAddProjectDialog() {
   const overlay = document.createElement('div');
   overlay.className = 'add-project-overlay';
 
   const dialog = document.createElement('div');
   dialog.className = 'add-project-dialog';
 
+  // Load remote SSH targets for the Remote tab.
+  let remoteTargets = [];
+  try { remoteTargets = await window.api.getRemoteTargets(); } catch {}
+  const buildHostOptions = (targets) =>
+    (targets.length ? '' : '<option value="" disabled selected>(no hosts yet)</option>') +
+    targets.map(h => `<option value="${escapeHtml(h.id)}">${escapeHtml(h.label)}${h.source === 'config' ? ' (ssh config)' : ''}</option>`).join('') +
+    '<option value="__add__">+ Add new host…</option>';
+  const hostOptions = buildHostOptions(remoteTargets);
+
   dialog.innerHTML = `
     <h3>Add Project</h3>
-    <div class="add-project-hint">Select a folder to create a new project. To start a session in an existing project, use the + on its project header.</div>
-    <div class="folder-input-row">
-      <input type="text" id="add-project-path" placeholder="/path/to/project" autocomplete="off" spellcheck="false">
-      <button class="add-project-browse-btn">Browse</button>
+    <div class="add-project-tabs">
+      <button class="add-project-tab selected" data-tab="local">Local folder</button>
+      <button class="add-project-tab" data-tab="remote">Remote (SSH)</button>
+    </div>
+    <div id="add-project-local">
+      <div class="add-project-hint">Select a folder to create a new project. To start a session in an existing project, use the + on its project header.</div>
+      <div class="folder-input-row">
+        <input type="text" id="add-project-path" placeholder="/path/to/project" autocomplete="off" spellcheck="false">
+        <button class="add-project-browse-btn">Browse</button>
+      </div>
+    </div>
+    <div id="add-project-remote" style="display:none">
+      <div class="add-project-hint">Choose an SSH host and a remote directory — or pick <strong>+ Add new host…</strong> to define one here. If the host needs a password, click <strong>Connect</strong> to log in once, then Browse.</div>
+      <div class="settings-field">
+        <div class="settings-field-info"><span class="settings-label">Host</span></div>
+        <div class="settings-field-control folder-input-row">
+          <select class="settings-select" id="add-remote-host">${hostOptions}</select>
+          <button class="add-project-browse-btn" id="add-remote-connect" type="button" title="Log in / verify the connection">Connect</button>
+        </div>
+      </div>
+      <div class="settings-field">
+        <div class="settings-field-info"><span class="settings-label">Remote directory</span></div>
+        <div class="settings-field-control folder-input-row">
+          <input type="text" class="settings-input" id="add-remote-path" placeholder="~/path/to/project" value="~">
+          <button class="add-project-browse-btn" id="add-remote-browse" type="button">Browse</button>
+        </div>
+      </div>
     </div>
     <div class="add-project-error" id="add-project-error"></div>
     <div class="add-project-actions">
@@ -453,29 +944,47 @@ function showAddProjectDialog() {
 
   const pathInput = dialog.querySelector('#add-project-path');
   const errorEl = dialog.querySelector('#add-project-error');
+  const localPane = dialog.querySelector('#add-project-local');
+  const remotePane = dialog.querySelector('#add-project-remote');
+  let tab = 'local';
   pathInput.focus();
+
+  dialog.querySelectorAll('.add-project-tab').forEach(btn => {
+    btn.onclick = () => {
+      tab = btn.dataset.tab;
+      dialog.querySelectorAll('.add-project-tab').forEach(b => b.classList.toggle('selected', b === btn));
+      localPane.style.display = tab === 'local' ? '' : 'none';
+      remotePane.style.display = tab === 'remote' ? '' : 'none';
+      errorEl.style.display = 'none';
+    };
+  });
 
   function close() {
     overlay.remove();
     document.removeEventListener('keydown', onKey);
   }
 
-  async function addProject() {
-    const projectPath = pathInput.value.trim();
-    if (!projectPath) {
-      errorEl.textContent = 'Please enter a folder path.';
-      errorEl.style.display = 'block';
-      return;
-    }
-    errorEl.style.display = 'none';
-    const result = await window.api.addProject(projectPath);
-    if (result.error) {
-      errorEl.textContent = result.error;
-      errorEl.style.display = 'block';
-      return;
-    }
-    close();
+  function showError(msg) { errorEl.textContent = msg; errorEl.style.display = 'block'; }
 
+  async function addProject() {
+    errorEl.style.display = 'none';
+    if (tab === 'remote') {
+      const hostSel = dialog.querySelector('#add-remote-host');
+      if (!hostSel) { showError('No SSH hosts configured. Add them in Settings → Remote Hosts.'); return; }
+      const hostId = hostSel.value;
+      if (!hostId || hostId === '__add__') { showError('Select or add a host.'); return; }
+      const remotePath = dialog.querySelector('#add-remote-path').value.trim() || '~';
+      const result = await window.api.addRemoteProject({ hostId, remotePath });
+      if (result.error) { showError(result.error); return; }
+      close();
+      await loadProjects();
+      return;
+    }
+    const projectPath = pathInput.value.trim();
+    if (!projectPath) { showError('Please enter a folder path.'); return; }
+    const result = await window.api.addProject(projectPath);
+    if (result.error) { showError(result.error); return; }
+    close();
     await loadProjects();
   }
 
@@ -483,6 +992,62 @@ function showAddProjectDialog() {
     const folder = await window.api.browseFolder();
     if (folder) pathInput.value = folder;
   };
+
+  // "+ Add new host…" in the host dropdown opens an inline add-host form.
+  const hostSelEl = dialog.querySelector('#add-remote-host');
+  if (hostSelEl) {
+    let prevValue = hostSelEl.value;
+    hostSelEl.addEventListener('change', async () => {
+      if (hostSelEl.value !== '__add__') { prevValue = hostSelEl.value; return; }
+      const saved = await showAddHostDialog();
+      if (saved) {
+        try { remoteTargets = await window.api.getRemoteTargets(); } catch {}
+        hostSelEl.innerHTML = buildHostOptions(remoteTargets);
+        hostSelEl.value = saved.id;
+        prevValue = hostSelEl.value;
+      } else {
+        hostSelEl.value = prevValue;
+      }
+    });
+  }
+
+  const isRealHost = () => { const v = hostSelEl && hostSelEl.value; return v && v !== '__add__'; };
+
+  // Remote directory Browse
+  const remoteBrowseBtn = dialog.querySelector('#add-remote-browse');
+  if (remoteBrowseBtn) {
+    remoteBrowseBtn.onclick = async () => {
+      if (!isRealHost()) { showError('Select or add a host first.'); return; }
+      const hostSel = dialog.querySelector('#add-remote-host');
+      const remotePathInput = dialog.querySelector('#add-remote-path');
+      const t = remoteTargets.find(h => h.id === hostSel.value);
+      const host = { id: hostSel.value, label: (t && t.label) || hostSel.value };
+      const picked = await showRemoteDirBrowser(host, remotePathInput.value.trim() || '~');
+      if (picked) remotePathInput.value = picked;
+    };
+  }
+
+  // Interactive Connect: open a real shell to the selected host to authenticate
+  // (password/pubkey/legacy). Closes this dialog and warms the connection so a
+  // subsequent Add → Browse works. The host label carries the ssh-config suffix,
+  // so strip it back to the pickable label for the session.
+  const remoteConnectBtn = dialog.querySelector('#add-remote-connect');
+  if (remoteConnectBtn) {
+    remoteConnectBtn.onclick = async () => {
+      if (!isRealHost()) { showError('Select or add a host first.'); return; }
+      const hostSel = dialog.querySelector('#add-remote-host');
+      const t = remoteTargets.find(h => h.id === hostSel.value);
+      const host = { id: hostSel.value, label: (t && t.label) || hostSel.value };
+      const orig = remoteConnectBtn.textContent;
+      remoteConnectBtn.disabled = true;
+      remoteConnectBtn.textContent = 'Connecting…';
+      remoteConnectBtn.classList.remove('connected');
+      const ok = await connectRemoteHost(host);
+      remoteConnectBtn.disabled = false;
+      if (ok) { remoteConnectBtn.textContent = '✓ Connected'; remoteConnectBtn.classList.add('connected'); }
+      else { remoteConnectBtn.textContent = orig; }
+    };
+  }
 
   dialog.querySelector('.add-project-cancel-btn').onclick = close;
   dialog.querySelector('.add-project-add-btn').onclick = addProject;

--- a/public/dialogs.js
+++ b/public/dialogs.js
@@ -26,6 +26,22 @@ async function resolveDefaultSessionOptions(project) {
 async function forkSession(session, project) {
   const options = await resolveDefaultSessionOptions(project);
   options.forkFrom = session.sessionId;
+  // Remote sessions fork on the host (claude --resume <id> --fork-session).
+  if (session.remote || (project && project.remote)) {
+    const host = {
+      id: (project && project.hostId) || session.hostId || session.source,
+      label: (project && project.hostLabel) || session.remoteLabel,
+    };
+    launchRemoteSession(host, {
+      remoteMode: 'claude',
+      remoteDir: (project && project.remotePath) || session.remotePath || '~',
+      forkFrom: session.sessionId,
+      permissionMode: options.permissionMode,
+      dangerouslySkipPermissions: options.dangerouslySkipPermissions,
+      addDirs: options.addDirs,
+    });
+    return;
+  }
   launchNewSession(project, options);
 }
 
@@ -243,6 +259,7 @@ async function launchRemoteSession(host, opts) {
     remoteHostId: host.id,
     remoteMode: mode,
     remoteDir,
+    forkFrom: options.forkFrom || null,
     dangerouslySkipPermissions: options.dangerouslySkipPermissions,
     permissionMode: options.permissionMode,
     addDirs: options.addDirs,
@@ -710,8 +727,11 @@ function connectRemoteHost(host) {
       _rcExit = (id, code) => {
         if (id !== connectId) return;
         _rcData = null; _rcExit = null;
-        if (code === 0) finish(true);
-        else {
+        if (code === 0) {
+          // Master is now live — index this host's past remote sessions (Phase 2).
+          if (window.api.syncRemoteHost) window.api.syncRemoteHost(host.id).catch(() => {});
+          finish(true);
+        } else {
           const lastLine = buffer.split('\n').map(s => s.trim()).filter(Boolean).slice(-1)[0] || '';
           showError('Connection failed' + (lastLine ? ': ' + lastLine : ' (exit ' + code + ').'));
         }
@@ -978,6 +998,9 @@ async function showAddProjectDialog() {
       if (result.error) { showError(result.error); return; }
       close();
       await loadProjects();
+      // Index this project's past sessions now (connect happened before it was
+      // registered, so the connect-time sync saw no projects for this host).
+      if (window.api.syncRemoteHost) window.api.syncRemoteHost(hostId).catch(() => {});
       return;
     }
     const projectPath = pathInput.value.trim();

--- a/public/jsonl-viewer.js
+++ b/public/jsonl-viewer.js
@@ -564,6 +564,10 @@ async function showJsonlViewer(session) {
   jsonlViewerSessionId.textContent = session.sessionId;
   jsonlViewerBody.innerHTML = '';
 
+  if (result.needsConnect) {
+    jsonlViewerBody.innerHTML = '<div class="plans-empty">Connect to <b>' + escapeHtml(result.hostLabel || 'the remote host') + '</b> to view this session.</div>';
+    return;
+  }
   if (result.error) {
     jsonlViewerBody.innerHTML = '<div class="plans-empty">Error loading messages: ' + escapeHtml(result.error) + '</div>';
     return;

--- a/public/settings-panel.js
+++ b/public/settings-panel.js
@@ -79,6 +79,12 @@
     let shellProfiles = [];
     try { shellProfiles = await window.api.getShellProfiles(); } catch {};
 
+    // Discover remote SSH targets (global settings only)
+    let remoteTargets = [];
+    if (!isProject) {
+      try { remoteTargets = await window.api.getRemoteTargets(); } catch {}
+    }
+
     settingsViewerBody.innerHTML = `
     <div class="settings-form">
       <div class="settings-section">
@@ -237,6 +243,18 @@
       </div>` : ''}
 
       ${!isProject ? `<div class="settings-section">
+        <div class="settings-section-title">Remote Hosts (SSH)</div>
+        <div class="settings-description" style="margin-bottom:10px">Hosts from <code>~/.ssh/config</code> are imported automatically. Add extra hosts below. Authentication uses your SSH agent/keys — passwords are never stored.</div>
+        <div id="sv-remote-config-list" class="remote-config-list"></div>
+        <div id="sv-remote-manual-list" class="remote-manual-list"></div>
+        <div class="remote-hosts-actions">
+          <button class="settings-check-updates-btn" id="sv-remote-add-btn" type="button">Add Host</button>
+          <button class="settings-save-btn" id="sv-remote-save-btn" type="button">Save Hosts</button>
+        </div>
+        <div id="sv-remote-status" class="remote-hosts-status"></div>
+      </div>` : ''}
+
+      ${!isProject ? `<div class="settings-section">
         <div class="settings-section-title">Updates</div>
         <div class="settings-field">
           <div class="settings-field-info">
@@ -375,6 +393,137 @@
       checkUpdatesBtn.addEventListener('click', () => {
         window.api.updaterCheck();
       });
+    }
+
+    // Remote Hosts section (global settings only)
+    const remoteManualList = settingsViewerBody.querySelector('#sv-remote-manual-list');
+    if (remoteManualList) {
+      const configHosts = remoteTargets.filter(h => h.source === 'config');
+      const toEditable = (h) => ({
+        id: h.id, label: h.label || '', user: h.user || '', host: h.host || '', port: h.port || '',
+        identityFile: h.identityFile || '',
+        options: Array.isArray(h.options) ? h.options.join(', ') : (h.options || ''),
+      });
+      let manualHosts = remoteTargets.filter(h => h.source === 'manual').map(toEditable);
+      const statusEl = settingsViewerBody.querySelector('#sv-remote-status');
+      const configListEl = settingsViewerBody.querySelector('#sv-remote-config-list');
+
+      const setStatus = (msg, kind) => {
+        statusEl.textContent = msg || '';
+        statusEl.className = 'remote-hosts-status' + (kind ? ' ' + kind : '');
+      };
+
+      const renderConfig = () => {
+        if (!configHosts.length) { configListEl.innerHTML = ''; return; }
+        configListEl.innerHTML = '<div class="remote-config-title">From ~/.ssh/config</div>' +
+          configHosts.map(h =>
+            `<div class="remote-host-row">
+               <span class="remote-host-name">${escapeHtml(h.label)}</span>
+               <span class="remote-host-detail">${escapeHtml((h.user ? h.user + '@' : '') + (h.hostName || h.host || ''))}${h.port ? ':' + h.port : ''}</span>
+               <button class="remote-connect-btn" type="button" data-id="${escapeHtml(h.id)}" data-label="${escapeHtml(h.label)}">Connect</button>
+               <button class="remote-test-btn" type="button" data-id="${escapeHtml(h.id)}">Test</button>
+             </div>`).join('');
+      };
+
+      const renderManual = () => {
+        remoteManualList.innerHTML = manualHosts.map((h, i) =>
+          `<div class="remote-host-card" data-i="${i}">
+             <div class="remote-host-row">
+               <input class="settings-input" data-f="label" placeholder="label" value="${escapeHtml(h.label)}" style="width:100px">
+               <input class="settings-input" data-f="user" placeholder="user" value="${escapeHtml(h.user)}" style="width:80px">
+               <input class="settings-input" data-f="host" placeholder="host" value="${escapeHtml(h.host)}" style="width:150px">
+               <input class="settings-input" data-f="port" placeholder="22" value="${escapeHtml(String(h.port || ''))}" style="width:56px">
+             </div>
+             <div class="remote-host-row">
+               <input class="settings-input" data-f="identityFile" placeholder="identity file (e.g. ~/.ssh/id_ed25519)" value="${escapeHtml(h.identityFile)}" style="flex:1;min-width:180px">
+             </div>
+             <div class="remote-host-row">
+               <input class="settings-input" data-f="options" title="Extra ssh -o options for legacy/special hosts (e.g. HostKeyAlgorithms=+ssh-rsa, PreferredAuthentications=password). Leave blank for most hosts." placeholder="extra options, comma-sep (e.g. HostKeyAlgorithms=+ssh-rsa, PreferredAuthentications=password)" value="${escapeHtml(h.options)}" style="flex:1;min-width:220px">
+             </div>
+             <div class="remote-host-row remote-host-actions">
+               ${h.id ? `<button class="remote-connect-btn" type="button" data-id="${escapeHtml(h.id)}" data-label="${escapeHtml(h.label || h.host)}">Connect</button>
+               <button class="remote-test-btn" type="button" data-id="${escapeHtml(h.id)}">Test</button>` : '<span class="remote-host-detail">Save to enable Connect/Test</span>'}
+               <button class="remote-writecfg-btn" type="button" data-i="${i}">→ ~/.ssh/config</button>
+               <button class="remote-remove-btn" type="button" data-i="${i}" title="Remove">✕</button>
+             </div>
+           </div>`).join('');
+        remoteManualList.querySelectorAll('.remote-host-card').forEach(card => {
+          const i = Number(card.dataset.i);
+          card.querySelectorAll('input').forEach(inp => {
+            inp.addEventListener('input', () => { manualHosts[i][inp.dataset.f] = inp.value; manualHosts[i].id = undefined; });
+          });
+          const rm = card.querySelector('.remote-remove-btn');
+          if (rm) rm.addEventListener('click', () => { manualHosts.splice(i, 1); renderManual(); });
+        });
+      };
+
+      settingsViewerBody.querySelector('#sv-remote-add-btn').addEventListener('click', () => {
+        manualHosts.push({ label: '', user: '', host: '', port: '', identityFile: '', options: '' });
+        renderManual();
+      });
+
+      settingsViewerBody.querySelector('#sv-remote-save-btn').addEventListener('click', async () => {
+        const toSave = manualHosts.filter(h => h.host && String(h.host).trim());
+        try {
+          const res = await window.api.saveRemoteHosts(toSave);
+          if (res && res.ok) {
+            setStatus('Saved ' + toSave.length + ' host(s).', 'ok');
+            manualHosts = (res.hosts || []).filter(h => h.source === 'manual').map(toEditable);
+            renderManual();
+          } else {
+            setStatus('Failed to save hosts.', 'err');
+          }
+        } catch (err) { setStatus('Save error: ' + err.message, 'err'); }
+      });
+
+      // Delegated handler for Connect / Test / write-config, bound to the freshly
+      // rendered form so listeners don't accumulate across re-opens.
+      settingsViewerBody.querySelector('.settings-form').addEventListener('click', async (e) => {
+        // Interactive Connect: open a real shell to the host (any auth) — warms the
+        // shared connection so Browse/sessions work right after.
+        const conn = e.target.closest('.remote-connect-btn');
+        if (conn) {
+          const host = { id: conn.dataset.id, label: conn.dataset.label || conn.dataset.id };
+          const orig = conn.textContent;
+          conn.disabled = true; conn.textContent = 'Connecting…';
+          setStatus('Connecting to ' + host.label + '…');
+          let ok = false;
+          try { ok = (typeof connectRemoteHost === 'function') ? await connectRemoteHost(host) : false; } catch {}
+          conn.disabled = false;
+          if (ok) { conn.textContent = '✓ Connected'; conn.classList.add('connected'); setStatus('✓ ' + host.label + ' connected (ready to Browse).', 'ok'); }
+          else { conn.textContent = orig; setStatus('', ''); }
+          return;
+        }
+        // Write a manual host into ~/.ssh/config.
+        const wcfg = e.target.closest('.remote-writecfg-btn');
+        if (wcfg) {
+          const h = manualHosts[Number(wcfg.dataset.i)];
+          if (!h || !h.host || !String(h.host).trim()) { setStatus('Enter a host first.', 'err'); return; }
+          wcfg.disabled = true;
+          try {
+            const r = await window.api.writeSshConfig(h);
+            if (r.ok) setStatus('✓ Wrote "' + r.label + '" to ~/.ssh/config. Reopen settings to see it under imported hosts.', 'ok');
+            else setStatus('✗ ' + (r.error || 'failed to write config'), 'err');
+          } catch (err) { setStatus('✗ ' + err.message, 'err'); }
+          wcfg.disabled = false;
+          return;
+        }
+        // Quick non-interactive reachability probe.
+        const btn = e.target.closest('.remote-test-btn');
+        if (!btn) return;
+        const id = btn.dataset.id;
+        const old = btn.textContent;
+        btn.disabled = true; btn.textContent = 'Testing…';
+        setStatus('Testing ' + id + '…');
+        try {
+          const r = await window.api.testRemoteHost(id);
+          setStatus((r.reachable ? '✓ ' : '✗ ') + id + ': ' + (r.message || (r.ok ? 'reachable' : 'failed')), r.reachable ? 'ok' : 'err');
+        } catch (err) { setStatus('✗ test error: ' + err.message, 'err'); }
+        btn.disabled = false; btn.textContent = old;
+      });
+
+      renderConfig();
+      renderManual();
     }
 
     // Remove project button

--- a/public/sidebar.js
+++ b/public/sidebar.js
@@ -284,8 +284,14 @@ function renderProjects(projects, resort) {
     const header = document.createElement('div');
     header.className = 'project-header';
     header.id = 'ph-' + fId;
-    const shortName = project.projectPath.split('/').filter(Boolean).slice(-2).join('/');
-    header.innerHTML = `<span class="arrow">&#9660;</span> <span class="project-name">${shortName}</span>`;
+    let shortName, remotePrefix = '';
+    if (project.remote) {
+      shortName = `${project.hostLabel} : ${project.remotePath || '~'}`;
+      remotePrefix = '<span class="remote-badge" title="Remote SSH host">SSH</span> ';
+    } else {
+      shortName = project.projectPath.split('/').filter(Boolean).slice(-2).join('/');
+    }
+    header.innerHTML = `<span class="arrow">&#9660;</span> ${remotePrefix}<span class="project-name">${shortName}</span>`;
 
     const scheduleBtn = document.createElement('button');
     scheduleBtn.className = 'project-schedule-btn';
@@ -644,7 +650,10 @@ function buildSessionItem(session) {
   const item = document.createElement('div');
   item.className = 'session-item';
   item.id = 'si-' + session.sessionId;
-  if (session.type === 'terminal') item.classList.add('is-terminal');
+  // A remote Claude session runs `claude` (not a plain shell), so it should read
+  // like a Claude session — no terminal badge/styling, just the SSH badge.
+  const isRemoteClaude = session.remote && session.remoteMode !== 'shell';
+  if (session.type === 'terminal' && !isRemoteClaude) item.classList.add('is-terminal');
   if (session.archived) item.classList.add('archived-item');
   if (activePtyIds.has(session.sessionId)) item.classList.add('has-running-pty');
   if (attentionSessions.has(session.sessionId)) item.classList.add('needs-attention');
@@ -686,11 +695,18 @@ function buildSessionItem(session) {
   metaEl.className = 'session-meta';
   metaEl.textContent = timeStr + (session.messageCount ? ' \u00b7 ' + session.messageCount + ' msgs' : '');
 
-  if (session.type === 'terminal') {
+  if (session.type === 'terminal' && !isRemoteClaude) {
     const badge = document.createElement('span');
     badge.className = 'terminal-badge';
     badge.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>';
     summaryEl.prepend(badge);
+  }
+  if (session.remote) {
+    const rbadge = document.createElement('span');
+    rbadge.className = 'remote-badge';
+    rbadge.textContent = 'SSH';
+    if (session.remoteLabel) rbadge.title = 'Remote: ' + session.remoteLabel;
+    summaryEl.prepend(rbadge);
   }
   info.appendChild(summaryEl);
   info.appendChild(idEl);

--- a/public/sidebar.js
+++ b/public/sidebar.js
@@ -305,6 +305,15 @@ function renderProjects(projects, resort) {
     settingsBtn.innerHTML = ICONS.gear(16);
     header.appendChild(settingsBtn);
 
+    // Remote projects: refresh past sessions from the host (Phase 2 indexing).
+    if (project.remote) {
+      const refreshBtn = document.createElement('button');
+      refreshBtn.className = 'project-refresh-btn';
+      refreshBtn.title = 'Refresh remote sessions';
+      refreshBtn.innerHTML = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>';
+      header.appendChild(refreshBtn);
+    }
+
     const archiveGroupBtn = document.createElement('button');
     archiveGroupBtn.className = 'project-archive-btn';
     archiveGroupBtn.title = 'Archive all sessions';
@@ -460,6 +469,17 @@ function rebindSidebarEvents(projects) {
     if (settingsBtn) {
       settingsBtn.onclick = (e) => { e.stopPropagation(); openSettingsViewer('project', project.projectPath); };
     }
+    const refreshBtn = header.querySelector('.project-refresh-btn');
+    if (refreshBtn) {
+      refreshBtn.onclick = async (e) => {
+        e.stopPropagation();
+        if (!project.hostId || !window.api.syncRemoteHost) return;
+        refreshBtn.classList.add('spinning');
+        try { await window.api.syncRemoteHost(project.hostId); } catch {}
+        refreshBtn.classList.remove('spinning');
+        loadProjects();
+      };
+    }
     const archiveGroupBtn = header.querySelector('.project-archive-btn');
     if (archiveGroupBtn) {
       archiveGroupBtn.onclick = async (e) => {
@@ -480,7 +500,7 @@ function rebindSidebarEvents(projects) {
       };
     }
     header.onclick = (e) => {
-      if (e.target.closest('.project-new-btn') || e.target.closest('.project-archive-btn') || e.target.closest('.project-settings-btn') || e.target.closest('.project-schedule-btn')) return;
+      if (e.target.closest('.project-new-btn') || e.target.closest('.project-archive-btn') || e.target.closest('.project-settings-btn') || e.target.closest('.project-schedule-btn') || e.target.closest('.project-refresh-btn')) return;
       header.classList.toggle('collapsed');
     };
   }

--- a/public/style.css
+++ b/public/style.css
@@ -2695,8 +2695,20 @@ body { display: flex; flex-direction: column; }
   align-items: center;
 }
 
+.add-project-dialog .folder-input-row select {
+  flex: 1;
+  min-width: 0; /* allow the select to shrink so it never overlaps the adjacent button */
+}
+
+/* Remote tab rows: fixed-width label + flexible control, so a widening button
+   (Connect -> Connecting… -> ✓ Connected) can never reflow into the label. */
+#add-project-remote .settings-field-info { flex: 0 0 130px; }
+#add-project-remote .settings-field-control { flex: 1 1 auto; min-width: 0; }
+#add-remote-connect { min-width: 116px; text-align: center; justify-content: center; flex: 0 0 auto; }
+
 .add-project-dialog .folder-input-row input {
   flex: 1;
+  min-width: 0;
   background: rgba(255,255,255,0.05);
   border: 1px solid rgba(255,255,255,0.1);
   border-radius: 6px;
@@ -3464,11 +3476,203 @@ body { display: flex; flex-direction: column; }
   top: -1px;
 }
 
+.remote-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  line-height: 1;
+  padding: 2px 4px;
+  margin-right: 5px;
+  border-radius: 3px;
+  color: #6cb6ff;
+  background: rgba(108, 182, 255, 0.14);
+  border: 1px solid rgba(108, 182, 255, 0.35);
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+}
+
 /* Terminal sessions: green status dot */
 .session-item.is-terminal .session-status-dot.running {
   background: #3ecf5a;
   box-shadow: 0 0 6px rgba(62,207,90,0.5);
 }
+
+/* Remote hosts settings section */
+.remote-config-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  opacity: 0.6;
+  margin: 4px 0 6px;
+  padding-left: 2px;
+}
+/* Imported host list: styled as a settings-style table (matches the rows in the
+   Application section — rounded group, dividers, label left / controls right). */
+.remote-config-list {
+  margin-bottom: 12px;
+  border-radius: 10px;
+  overflow: hidden;
+}
+.remote-config-list .remote-config-title {
+  margin: 0;
+  padding: 8px 18px;
+  background: rgba(255,255,255,0.02);
+}
+.remote-host-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 0;
+}
+.remote-config-list .remote-host-row {
+  padding: 12px 18px;
+  min-height: 48px;
+  background: rgba(255,255,255,0.02);
+  border-top: 1px solid rgba(255,255,255,0.05);
+}
+.remote-host-name { font-size: 13.5px; font-weight: 600; letter-spacing: -0.01em; min-width: 130px; color: #e0e0f0; }
+.remote-host-detail { opacity: 0.65; flex: 1; font-size: 12.5px; }
+.remote-hosts-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+.remote-test-btn, .remote-remove-btn, .remote-connect-btn, .remote-writecfg-btn {
+  background: rgba(127,127,127,0.12);
+  border: 1px solid rgba(127,127,127,0.3);
+  border-radius: 4px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 11px;
+  padding: 3px 8px;
+}
+.remote-remove-btn { padding: 3px 7px; }
+.remote-connect-btn {
+  color: #6cb6ff;
+  border-color: rgba(108,182,255,0.45);
+  background: rgba(108,182,255,0.12);
+}
+.remote-test-btn:hover, .remote-remove-btn:hover, .remote-connect-btn:hover, .remote-writecfg-btn:hover { background: rgba(127,127,127,0.22); }
+.remote-connect-btn:hover { background: rgba(108,182,255,0.22); }
+
+/* Connected state for Connect buttons */
+.remote-connect-btn.connected,
+.add-project-browse-btn.connected {
+  color: #3ecf5a;
+  border-color: rgba(62,207,90,0.5);
+  background: rgba(62,207,90,0.12);
+}
+
+/* Add-host example-option chips */
+.ah-opt-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 6px;
+}
+.ah-chip {
+  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  padding: 2px 6px;
+  border-radius: 10px;
+  border: 1px solid rgba(108,182,255,0.35);
+  background: rgba(108,182,255,0.10);
+  color: #6cb6ff;
+  cursor: pointer;
+}
+.ah-chip:hover { background: rgba(108,182,255,0.20); }
+
+/* Host-key fingerprint block in the Connect verify popup */
+.auth-fingerprint {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: rgba(127,127,127,0.10);
+  border: 1px solid rgba(127,127,127,0.25);
+  border-radius: 6px;
+  padding: 10px;
+  margin: 10px 0;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+/* Interactive Connect popup (embedded auth terminal) */
+.remote-connect-dialog { width: 640px; max-width: 92vw; }
+.remote-connect-hint { font-size: 12px; opacity: 0.75; margin-bottom: 10px; }
+.remote-connect-term {
+  height: 260px;
+  background: #000;
+  border-radius: 6px;
+  padding: 6px;
+  overflow: hidden;
+}
+.remote-connect-msg { margin-top: 8px; font-size: 12px; min-height: 14px; }
+.remote-connect-msg.ok { color: #3ecf5a; }
+.remote-connect-msg.err { color: #ff6b6b; }
+
+/* Manual host card (multi-field editor) */
+.remote-host-card {
+  border: 1px solid rgba(127,127,127,0.22);
+  border-radius: 6px;
+  padding: 8px;
+  margin-bottom: 8px;
+}
+.remote-host-card .remote-host-row { flex-wrap: wrap; }
+.remote-host-actions { gap: 6px; }
+.remote-hosts-status {
+  margin-top: 8px;
+  font-size: 12px;
+  min-height: 16px;
+  word-break: break-word;
+}
+.remote-hosts-status.ok { color: #3ecf5a; }
+.remote-hosts-status.err { color: #ff6b6b; }
+
+/* Add-project Local | Remote tabs */
+.add-project-tabs { display: flex; gap: 6px; margin-bottom: 12px; }
+.add-project-tab {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid rgba(127,127,127,0.3);
+  background: transparent;
+  color: inherit;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.add-project-tab.selected {
+  background: rgba(108,182,255,0.16);
+  border-color: rgba(108,182,255,0.5);
+}
+
+/* Remote directory browser — must stack above the Add Project overlay (z 9999)
+   since Browse can be opened from within it. */
+.remote-browser-overlay { z-index: 10001; }
+.remote-browser-list {
+  margin-top: 10px;
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid rgba(127,127,127,0.25);
+  border-radius: 6px;
+}
+.remote-browser-item {
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 13px;
+  border-bottom: 1px solid rgba(127,127,127,0.12);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.remote-browser-item:hover { background: rgba(108,182,255,0.14); }
+.remote-browser-up { opacity: 0.8; }
+.remote-browser-status { padding: 10px; opacity: 0.6; font-size: 12px; }
+.remote-browser-msg { margin-top: 8px; font-size: 12px; color: #e0a54a; min-height: 14px; }
 
 /* ========== FILE PANEL (MCP Bridge) ========== */
 

--- a/public/style.css
+++ b/public/style.css
@@ -2880,6 +2880,42 @@ body { display: flex; flex-direction: column; }
   color: #888;
 }
 
+/* Project header refresh button (remote projects — re-index past sessions) */
+.project-refresh-btn {
+  background: transparent;
+  border: none;
+  color: #7a7a90;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  line-height: 0;
+  transition: all 0.15s;
+  opacity: 0.7;
+}
+
+.project-refresh-btn svg { display: block; }
+
+.project-header:hover .project-refresh-btn { opacity: 1; }
+
+.project-refresh-btn:hover {
+  background: rgba(90,160,255,0.12);
+  color: #6aa0e0;
+}
+
+.project-refresh-btn.spinning svg {
+  animation: spin-refresh 0.8s linear infinite;
+}
+
+@keyframes spin-refresh {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 /* ========== SETTINGS VIEWER ========== */
 #settings-viewer {
   position: absolute;

--- a/read-session-file.js
+++ b/read-session-file.js
@@ -1,12 +1,18 @@
 const path = require('path');
 const fs = require('fs');
 
-/** Parse a single .jsonl file into a session object (or null if invalid) */
-function readSessionFile(filePath, folder, projectPath) {
-  const sessionId = path.basename(filePath, '.jsonl');
+/**
+ * Parse raw JSONL content into a session object (or null if invalid).
+ * Pure — no filesystem access. Shared by local indexing (readSessionFile) and
+ * remote indexing (which streams content over SSH without touching local disk).
+ *
+ * meta: { sessionId, folder, projectPath, created?, modified? }
+ *   created/modified are used verbatim when supplied (local passes file stat times).
+ *   When omitted (remote), they fall back to the first/last entry timestamps.
+ */
+function parseSessionContent(content, meta) {
+  const { sessionId, folder, projectPath } = meta;
   try {
-    const stat = fs.statSync(filePath);
-    const content = fs.readFileSync(filePath, 'utf8');
     const lines = content.split('\n').filter(Boolean);
     let summary = '';
     let messageCount = 0;
@@ -14,8 +20,14 @@ function readSessionFile(filePath, folder, projectPath) {
     let slug = null;
     let customTitle = null;
     let aiTitle = null;
+    let firstTimestamp = null;
+    let lastTimestamp = null;
     for (const line of lines) {
       const entry = JSON.parse(line);
+      if (entry.timestamp) {
+        if (!firstTimestamp) firstTimestamp = entry.timestamp;
+        lastTimestamp = entry.timestamp;
+      }
       if (entry.slug && !slug) slug = entry.slug;
       if (entry.type === 'custom-title' && entry.customTitle) {
         customTitle = entry.customTitle;
@@ -44,11 +56,12 @@ function readSessionFile(filePath, folder, projectPath) {
       }
     }
     if (!summary || messageCount < 1) return null;
+    const created = meta.created != null ? meta.created : (firstTimestamp || '');
+    const modified = meta.modified != null ? meta.modified : (lastTimestamp || firstTimestamp || '');
     return {
       sessionId, folder, projectPath,
       summary, firstPrompt: summary,
-      created: stat.birthtime.toISOString(),
-      modified: stat.mtime.toISOString(),
+      created, modified,
       messageCount, textContent, slug, customTitle, aiTitle,
     };
   } catch {
@@ -56,4 +69,20 @@ function readSessionFile(filePath, folder, projectPath) {
   }
 }
 
-module.exports = { readSessionFile };
+/** Parse a single .jsonl file into a session object (or null if invalid) */
+function readSessionFile(filePath, folder, projectPath) {
+  const sessionId = path.basename(filePath, '.jsonl');
+  try {
+    const stat = fs.statSync(filePath);
+    const content = fs.readFileSync(filePath, 'utf8');
+    return parseSessionContent(content, {
+      sessionId, folder, projectPath,
+      created: stat.birthtime.toISOString(),
+      modified: stat.mtime.toISOString(),
+    });
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { readSessionFile, parseSessionContent };

--- a/remote-hosts.js
+++ b/remote-hosts.js
@@ -1,0 +1,276 @@
+// Remote SSH host model for Switchboard (Phase 1).
+//
+// Turns ~/.ssh/config entries and user-defined "manual" hosts into SSH shell
+// profiles that the terminal spawner (main.js) can hand to node-pty, and
+// assembles the command that runs on the remote host. Pure functions here are
+// unit-tested; the fs-backed helpers are thin wrappers over them.
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+// Single-quote a string for a POSIX shell, escaping embedded single quotes.
+function sshSingleQuote(s) {
+  return "'" + String(s).replace(/'/g, "'\\''") + "'";
+}
+
+// Parse an ~/.ssh/config document into host entries.
+// Only top-level `Host` blocks are considered; wildcard/negated aliases and
+// `Match` blocks are ignored. `Include` is not followed (Phase 1 limitation).
+function parseSshConfig(text) {
+  const hosts = [];
+  const seenAliases = new Set();
+  let current = null;
+  const flush = () => {
+    if (!current) return;
+    for (const alias of current.aliases) {
+      if (alias.includes('*') || alias.includes('?') || alias.startsWith('!')) continue;
+      if (seenAliases.has(alias)) continue; // first occurrence wins (ssh's own semantics)
+      seenAliases.add(alias);
+      hosts.push({
+        id: 'config:' + alias,
+        label: alias,
+        alias,
+        hostName: current.hostName || alias,
+        user: current.user,
+        port: current.port,
+        source: 'config',
+      });
+    }
+    current = null;
+  };
+
+  for (const raw of String(text || '').split(/\r?\n/)) {
+    const line = raw.replace(/#.*$/, '').trim();
+    if (!line) continue;
+    const m = line.match(/^(\S+)[\s=]+(.+)$/);
+    if (!m) continue;
+    const key = m[1].toLowerCase();
+    const value = m[2].trim();
+    if (key === 'host') {
+      flush();
+      current = { aliases: value.split(/\s+/).filter(Boolean), hostName: undefined, user: undefined, port: undefined };
+    } else if (key === 'match') {
+      flush(); // ignore Match blocks
+    } else if (current) {
+      if (key === 'hostname') current.hostName = value;
+      else if (key === 'user') current.user = value;
+      else if (key === 'port') current.port = parseInt(value, 10);
+    }
+  }
+  flush();
+  return hosts;
+}
+
+// Quote a remote directory for use in `cd <dir>`, expanding a leading ~ to
+// $HOME so the remote shell resolves it (single quotes would suppress it).
+function quoteRemoteDir(dir) {
+  if (dir === '~') return '$HOME';
+  if (dir.startsWith('~/')) return '$HOME/' + sshSingleQuote(dir.slice(2));
+  return sshSingleQuote(dir);
+}
+
+// Build the command executed on the remote host.
+//   mode 'claude': cd <dir> && exec <innerCmd>   (cd failure aborts — don't run in the wrong place)
+//   mode 'shell' : cd <dir> 2>/dev/null; exec login-shell   (cd is best-effort)
+// A home/empty dir needs no cd (a login shell already starts in $HOME).
+function buildRemoteCommand(mode, remoteDir, innerCmd) {
+  const hasDir = remoteDir && remoteDir !== '~' && String(remoteDir).trim() !== '';
+  const cd = hasDir ? 'cd ' + quoteRemoteDir(remoteDir) : '';
+  if (mode === 'shell') {
+    const shellExec = 'exec "${SHELL:-bash}" -l';
+    return cd ? cd + ' 2>/dev/null; ' + shellExec : shellExec;
+  }
+  const inner = 'exec ' + innerCmd;
+  return cd ? cd + ' && ' + inner : inner;
+}
+
+// The ssh options+target for a host, WITHOUT the -t PTY flag or -o test options.
+// Options must precede the target: ssh stops option parsing at the hostname.
+// Config hosts resolve everything (key, options, algorithms) from ~/.ssh/config,
+// so we only pass the alias. Manual hosts carry their own identity file and extra
+// -o options (e.g. legacy HostKeyAlgorithms=+ssh-rsa) inline.
+function hostTargetArgs(host) {
+  if (host.source === 'config') return [host.alias];
+  const args = [];
+  for (const opt of (host.options || [])) {
+    if (opt && String(opt).trim()) args.push('-o', String(opt).trim());
+  }
+  if (host.identityFile && String(host.identityFile).trim()) args.push('-i', String(host.identityFile).trim());
+  const port = host.port ? Number(host.port) : undefined;
+  if (port && port !== 22) args.push('-p', String(port));
+  args.push(host.user ? host.user + '@' + host.host : host.host);
+  return args;
+}
+
+// Full ssh args for an interactive session (forces a PTY with -t).
+function sshArgsForHost(host) {
+  return ['-t', ...hostTargetArgs(host)];
+}
+
+// A shell profile (as produced by shell-profiles.js) that spawns ssh.
+function buildSshProfile(host) {
+  const label = host.label || host.alias || host.host;
+  return {
+    id: 'ssh:' + host.id,
+    name: 'SSH — ' + label,
+    path: 'ssh',
+    args: sshArgsForHost(host),
+    remote: true,
+    remoteHost: host,
+  };
+}
+
+// ssh args for a non-interactive connectivity probe. BatchMode=yes ensures we
+// never block on a password prompt (key/agent auth only), and a short timeout
+// surfaces unreachable hosts quickly.
+function testConnectionArgs(host) {
+  return ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8', ...hostTargetArgs(host), 'true'];
+}
+
+// Stable synthetic project path for a remote project / session, so a persisted
+// remote project and the live sessions launched into it group together in the
+// sidebar. Must be produced identically wherever a remote path is formed.
+function remoteProjectPath(hostLabel, remotePath) {
+  return 'ssh://' + hostLabel + '/' + (remotePath && String(remotePath).trim() ? remotePath : '~');
+}
+
+// Classify a non-interactive ssh probe (see testConnectionArgs). BatchMode never
+// prompts, so a password-auth host "fails" — but its failure text tells us the
+// host is actually reachable and simply needs interactive auth on connect.
+function classifyConnResult(exitCode, output) {
+  const out = String(output || '');
+  if (exitCode === 0) return { status: 'ok', reachable: true, message: 'Reachable (passwordless key/agent auth works).' };
+  if (/permission denied|password:|publickey|authentication failed|too many authentication/i.test(out)) {
+    return { status: 'auth', reachable: true, message: 'Reachable — will prompt for password/key auth on connect.' };
+  }
+  if (/host key verification failed|authenticity of host|fingerprint|known_hosts/i.test(out)) {
+    return { status: 'hostkey', reachable: true, message: 'Reachable — first connection needs host-key confirmation (accept it when you launch a session).' };
+  }
+  if (/connection refused|could not resolve|name or service not known|no route to host|network is unreachable|operation timed out|connection timed out|timed out|connection closed/i.test(out)) {
+    return { status: 'unreachable', reachable: false, message: 'Unreachable: ' + (out.split('\n').filter(Boolean).slice(-1)[0] || 'no response') };
+  }
+  return { status: 'unknown', reachable: false, message: out.split('\n').filter(Boolean).slice(-1)[0] || 'Unknown result' };
+}
+
+// SSH connection-multiplexing options. A shared control socket per host lets the
+// directory browser (and repeated ops) reuse one authenticated connection, so you
+// only authenticate once per host and subsequent listings are instant.
+function controlArgs(socketPath) {
+  return ['-o', 'ControlMaster=auto', '-o', 'ControlPath=' + socketPath, '-o', 'ControlPersist=600'];
+}
+
+// Short, stable, length-bounded control-socket path for a host (unix socket paths
+// are capped ~104 bytes, so we hash the id rather than embed it).
+function controlSocketPath(baseDir, hostId) {
+  let h = 5381;
+  const s = String(hostId);
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return baseDir.replace(/\/$/, '') + '/swb-' + Math.abs(h).toString(36) + '.sock';
+}
+
+// Parse `ls -1Ap` output into the list of subdirectory names (lines the shell
+// marked with a trailing slash), stripped and sorted.
+function parseLsDirs(output) {
+  const dirs = [];
+  for (const raw of String(output || '').split(/\r?\n/)) {
+    const line = raw.replace(/\r$/, '');
+    if (line.endsWith('/')) {
+      const name = line.slice(0, -1);
+      if (name && name !== '.' && name !== '..') dirs.push(name);
+    }
+  }
+  return dirs.sort();
+}
+
+// ssh args to list directories at `path` on a host over the control socket.
+// BatchMode: never blocks on a prompt — if the connection isn't already
+// authenticated (no live master, no key auth) it fails fast and the caller
+// reports "needs auth" instead of hanging.
+function browseArgs(host, socketPath, path) {
+  const opts = ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8', ...controlArgs(socketPath)];
+  const cmd = 'ls -1Ap -- ' + quoteRemoteDir(path);
+  return [...opts, ...hostTargetArgs(host), cmd];
+}
+
+// --- fs-backed helpers (main process) ---
+
+function defaultSshConfigPath() {
+  return path.join(os.homedir(), '.ssh', 'config');
+}
+
+function readSshConfigHosts(configPath) {
+  try {
+    const p = configPath || defaultSshConfigPath();
+    if (!fs.existsSync(p)) return [];
+    return parseSshConfig(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function normalizeManualHost(h) {
+  const host = (h.host || '').trim();
+  const port = h.port ? Number(h.port) : undefined;
+  const user = (h.user || '').trim() || undefined;
+  const identityFile = (h.identityFile || '').trim() || undefined;
+  // options may arrive as an array or a free-form string (newline/comma separated)
+  let options = [];
+  if (Array.isArray(h.options)) {
+    options = h.options.map(o => String(o).trim()).filter(Boolean);
+  } else if (typeof h.options === 'string') {
+    options = h.options.split(/[\n,]+/).map(o => o.trim()).filter(Boolean);
+  }
+  const id = h.id || ('manual:' + (user ? user + '@' : '') + host + (port ? ':' + port : ''));
+  return { id, label: (h.label || '').trim() || host || id, host, user, port, identityFile, options, source: 'manual' };
+}
+
+// Render a host as an ~/.ssh/config `Host` block. ssh config uses "Key Value"
+// (space-separated), so options given as "Key=Value" are converted.
+function buildSshConfigEntry(host) {
+  const lines = ['Host ' + (host.label || host.alias || host.host)];
+  if (host.host) lines.push('    HostName ' + host.host);
+  if (host.user) lines.push('    User ' + host.user);
+  const port = host.port ? Number(host.port) : undefined;
+  if (port && port !== 22) lines.push('    Port ' + port);
+  if (host.identityFile) lines.push('    IdentityFile ' + host.identityFile);
+  for (const opt of (host.options || [])) {
+    const s = String(opt).trim();
+    if (!s) continue;
+    const eq = s.indexOf('=');
+    lines.push('    ' + (eq >= 0 ? s.slice(0, eq) + ' ' + s.slice(eq + 1) : s));
+  }
+  return lines.join('\n');
+}
+
+// Merge config-derived hosts with user-defined manual hosts (from settings).
+function loadRemoteHosts(manualHosts, configPath) {
+  const config = readSshConfigHosts(configPath);
+  const manual = (manualHosts || []).filter(h => h && h.host).map(normalizeManualHost);
+  return [...config, ...manual];
+}
+
+function findRemoteHost(id, manualHosts, configPath) {
+  return loadRemoteHosts(manualHosts, configPath).find(h => h.id === id) || null;
+}
+
+module.exports = {
+  parseSshConfig,
+  quoteRemoteDir,
+  buildRemoteCommand,
+  hostTargetArgs,
+  sshArgsForHost,
+  buildSshProfile,
+  testConnectionArgs,
+  remoteProjectPath,
+  classifyConnResult,
+  controlArgs,
+  controlSocketPath,
+  parseLsDirs,
+  browseArgs,
+  buildSshConfigEntry,
+  readSshConfigHosts,
+  normalizeManualHost,
+  loadRemoteHosts,
+  findRemoteHost,
+  defaultSshConfigPath,
+};

--- a/remote-hosts.js
+++ b/remote-hosts.js
@@ -134,6 +134,16 @@ function remoteProjectPath(hostLabel, remotePath) {
   return 'ssh://' + hostLabel + '/' + (remotePath && String(remotePath).trim() ? remotePath : '~');
 }
 
+// Inverse of remoteProjectPath: parse "ssh://<label>/<remotePath>" back into its
+// parts. Returns null for non-remote paths.
+function parseRemoteProjectPath(projectPath) {
+  if (typeof projectPath !== 'string' || !projectPath.startsWith('ssh://')) return null;
+  const rest = projectPath.slice('ssh://'.length);
+  const i = rest.indexOf('/');
+  if (i === -1) return { hostLabel: rest, remotePath: '~' };
+  return { hostLabel: rest.slice(0, i), remotePath: rest.slice(i + 1) || '~' };
+}
+
 // Classify a non-interactive ssh probe (see testConnectionArgs). BatchMode never
 // prompts, so a password-auth host "fails" — but its failure text tells us the
 // host is actually reachable and simply needs interactive auth on connect.
@@ -262,6 +272,7 @@ module.exports = {
   buildSshProfile,
   testConnectionArgs,
   remoteProjectPath,
+  parseRemoteProjectPath,
   classifyConnResult,
   controlArgs,
   controlSocketPath,

--- a/remote-index.js
+++ b/remote-index.js
@@ -1,0 +1,277 @@
+const path = require('path');
+
+/**
+ * Remote session indexing (Phase 2).
+ *
+ * Pure helpers below are unit-tested without SSH. The impure orchestration
+ * (syncRemoteHost) shells out over the existing ControlMaster connection and is
+ * exercised manually; it requires child_process lazily so this module stays
+ * import-safe for tests.
+ */
+
+/**
+ * Parse the remote listing command output. One line per remote .jsonl:
+ *   <jsonlPath>\t<mtimeEpochSeconds>\t<cwdRaw>
+ * where cwdRaw is the raw grep match `"cwd":"..."` (or empty).
+ * Returns [{ sessionId, path, folder, mtimeMs, modified, cwd }].
+ */
+function parseRemoteListing(text) {
+  const out = [];
+  if (!text) return out;
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    if (!line.trim()) continue;
+    const firstTab = line.indexOf('\t');
+    if (firstTab === -1) continue;
+    const secondTab = line.indexOf('\t', firstTab + 1);
+    if (secondTab === -1) continue;
+    const filePath = line.slice(0, firstTab);
+    const mtimeStr = line.slice(firstTab + 1, secondTab);
+    const cwdRaw = line.slice(secondTab + 1);
+    const mtimeSec = Number(mtimeStr);
+    if (!filePath || !Number.isFinite(mtimeSec)) continue;
+    const cwdMatch = cwdRaw.match(/"cwd":"([^"]*)"/);
+    const cwd = cwdMatch ? cwdMatch[1] : '';
+    const mtimeMs = Math.round(mtimeSec * 1000);
+    out.push({
+      sessionId: path.basename(filePath, '.jsonl'),
+      path: filePath,
+      folder: path.basename(path.dirname(filePath)),
+      mtimeMs,
+      modified: new Date(mtimeMs).toISOString(),
+      cwd,
+    });
+  }
+  return out;
+}
+
+/**
+ * Convert an absolute remote cwd into a display path relative to the remote home
+ * ("~" or "~/sub"), or leave it absolute when it lives outside home. Used to derive
+ * a remote project path per session so a whole host's sessions auto-group by dir.
+ */
+function cwdToDisplay(cwd, home) {
+  if (!cwd) return '~';
+  if (home && cwd === home) return '~';
+  if (home && cwd.startsWith(home + '/')) return '~' + cwd.slice(home.length);
+  return cwd;
+}
+
+/**
+ * Compare a remote listing against already-cached rows for the same host.
+ * cachedRows: [{ sessionId, modified }].
+ * Returns { toFetch: [listing entries new or mtime-changed], toDelete: [sessionIds gone] }.
+ */
+function diffChangedSessions(listing, cachedRows) {
+  const cached = new Map();
+  for (const r of cachedRows) cached.set(r.sessionId, r.modified);
+  const seen = new Set();
+  const toFetch = [];
+  for (const e of listing) {
+    seen.add(e.sessionId);
+    if (!cached.has(e.sessionId) || cached.get(e.sessionId) !== e.modified) {
+      toFetch.push(e);
+    }
+  }
+  const toDelete = [];
+  for (const id of cached.keys()) {
+    if (!seen.has(id)) toDelete.push(id);
+  }
+  return { toFetch, toDelete };
+}
+
+/**
+ * Decode a length-framed multi-file stream produced by the remote fetch command:
+ *   SWBF <byteLength> <path>\n<byteLength bytes>...
+ * Framing is length-based, so file content containing the marker is safe.
+ * Accepts a Buffer; returns [{ path, content }]. Incomplete trailing frames are dropped.
+ */
+function decodeFramedFiles(buf) {
+  const files = [];
+  if (!buf || buf.length === 0) return files;
+  let off = 0;
+  while (off < buf.length) {
+    const nl = buf.indexOf(0x0a, off); // '\n'
+    if (nl === -1) break;
+    const header = buf.toString('utf8', off, nl);
+    const m = header.match(/^SWBF (\d+) (.*)$/);
+    if (!m) break;
+    const size = parseInt(m[1], 10);
+    const filePath = m[2];
+    const start = nl + 1;
+    const end = start + size;
+    if (end > buf.length) break; // incomplete
+    files.push({ path: filePath, content: buf.toString('utf8', start, end) });
+    off = end;
+  }
+  return files;
+}
+
+// --- SSH command assembly (over the existing ControlMaster socket) ---
+
+const { controlArgs, hostTargetArgs, remoteProjectPath } = require('./remote-hosts');
+const { parseSessionContent } = require('./read-session-file');
+
+function shellSingleQuote(s) {
+  return "'" + String(s).replace(/'/g, "'\\''") + "'";
+}
+
+// Remote command that lists every session .jsonl with its mtime and cwd, one per
+// line: "<path>\t<mtimeEpoch>\t<cwdMatch>". stat -c (GNU) with a -f (BSD) fallback.
+const LISTING_SCRIPT =
+  'find "$HOME/.claude/projects" -maxdepth 2 -name \'*.jsonl\' -type f 2>/dev/null | ' +
+  'while IFS= read -r f; do ' +
+  'm=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null); ' +
+  'c=$(grep -m1 -o \'"cwd":"[^"]*"\' "$f" 2>/dev/null); ' +
+  'printf \'%s\\t%s\\t%s\\n\' "$f" "$m" "$c"; done';
+
+// Remote command that streams the given files length-framed (see decodeFramedFiles).
+function fetchScript(paths) {
+  const list = paths.map(shellSingleQuote).join(' ');
+  return `for f in ${list}; do ` +
+    's=$(stat -c %s "$f" 2>/dev/null || stat -f %z "$f" 2>/dev/null); ' +
+    '[ -n "$s" ] || continue; ' +
+    'printf \'SWBF %s %s\\n\' "$s" "$f"; cat "$f"; done';
+}
+
+function sshCmdArgs(host, sock, remoteCmd) {
+  const opts = ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8', ...controlArgs(sock)];
+  return [...opts, ...hostTargetArgs(host), remoteCmd];
+}
+
+// ssh args to cat a single remote session transcript (live "View messages").
+function remoteJsonlCatArgs(host, sock, folder, sessionId) {
+  const p = '"$HOME/.claude/projects/"' + shellSingleQuote(folder) + '/' +
+    shellSingleQuote(sessionId) + '.jsonl';
+  return sshCmdArgs(host, sock, 'cat ' + p);
+}
+
+function chunk(arr, n) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n));
+  return out;
+}
+
+// Capture a child process's stdout as a string or Buffer, rejecting on failure so
+// callers never index against a half-open connection.
+function spawnCapture(bin, args, mode) {
+  const cp = require('child_process');
+  return new Promise((resolve, reject) => {
+    let proc;
+    try { proc = cp.spawn(bin, args, { env: process.env }); }
+    catch (e) { return reject(e); }
+    const chunks = [];
+    let errStr = '';
+    const killer = setTimeout(() => { try { proc.kill(); } catch {} reject(new Error('ssh timed out')); }, 30000);
+    proc.stdout.on('data', (d) => chunks.push(d));
+    proc.stderr.on('data', (d) => { errStr += d.toString('utf8'); if (errStr.length > 4000) errStr = errStr.slice(-4000); });
+    proc.on('error', (e) => { clearTimeout(killer); reject(e); });
+    proc.on('close', (code) => {
+      clearTimeout(killer);
+      const buf = Buffer.concat(chunks);
+      if (code !== 0) {
+        return reject(Object.assign(new Error(`ssh exited ${code}: ${errStr.trim()}`), { code, stderr: errStr }));
+      }
+      resolve(mode === 'buffer' ? buf : buf.toString('utf8'));
+    });
+  });
+}
+
+function defaultRunText(host, sock) {
+  return (kind) => {
+    if (kind !== 'listing') return Promise.reject(new Error('unknown text kind: ' + kind));
+    return spawnCapture('ssh', sshCmdArgs(host, sock, LISTING_SCRIPT), 'utf8');
+  };
+}
+
+function defaultRunRaw(host, sock) {
+  return (_kind, paths) => spawnCapture('ssh', sshCmdArgs(host, sock, fetchScript(paths)), 'buffer');
+}
+
+/**
+ * Sync one connected host: list ALL its sessions → derive a remote project per
+ * session from its cwd (so the whole host auto-groups by directory) → fetch
+ * new/changed transcripts over SSH (no local copy) → upsert cache + FTS with
+ * source=host.id → delete rows whose files vanished.
+ * runText/runRaw are injectable for testing; production uses the SSH defaults.
+ * Rejects (without touching the DB) if the connection isn't live.
+ */
+async function syncRemoteHost({ host, sock, db, runText, runRaw, hostLabel }) {
+  runText = runText || defaultRunText(host, sock);
+  runRaw = runRaw || defaultRunRaw(host, sock);
+  const label = hostLabel || host.label || host.alias || host.id;
+
+  const listing = parseRemoteListing(await runText('listing'));
+  // Remote $HOME is the path prefix before /.claude/projects/ (same for every entry).
+  const home = listing.length ? listing[0].path.split('/.claude/projects/')[0] : '';
+  const assigned = listing
+    .filter((e) => e.cwd)
+    .map((e) => ({ ...e, projectPath: remoteProjectPath(label, cwdToDisplay(e.cwd, home)) }));
+
+  const cached = db.getCachedBySource(host.id);
+  const { toFetch, toDelete } = diffChangedSessions(assigned, cached);
+
+  const sessions = [];
+  for (const group of chunk(toFetch, 40)) {
+    const buf = await runRaw('fetch', group.map((e) => e.path));
+    const files = decodeFramedFiles(Buffer.isBuffer(buf) ? buf : Buffer.from(buf));
+    for (const file of files) {
+      const entry = group.find((e) => e.path === file.path);
+      if (!entry) continue;
+      const s = parseSessionContent(file.content, {
+        sessionId: entry.sessionId, folder: entry.folder,
+        projectPath: entry.projectPath, modified: entry.modified,
+      });
+      if (s) { s.source = host.id; sessions.push(s); }
+    }
+  }
+
+  if (sessions.length) {
+    db.upsertCachedSessions(sessions);
+    const entries = sessions.map((s) => {
+      const name = (db.getMeta && db.getMeta(s.sessionId)?.name) || s.customTitle || s.aiTitle || '';
+      return {
+        id: s.sessionId, type: 'session', folder: s.folder, source: host.id,
+        title: (name ? name + ' ' : '') + s.summary, body: s.textContent,
+      };
+    });
+    db.upsertSearchEntries(entries);
+    if (db.setName) for (const s of sessions) if (s.customTitle) db.setName(s.sessionId, s.customTitle);
+  }
+  for (const id of toDelete) {
+    db.deleteCachedSession(id);
+    db.deleteSearchSession(id);
+  }
+  return { ok: true, indexed: sessions.length, deleted: toDelete.length };
+}
+
+/**
+ * Live "View messages" for a remote session: cat the transcript over the shared
+ * SSH connection (no local copy) and parse it into entries. Rejects if the master
+ * is not live so the caller can prompt the user to Connect.
+ */
+async function fetchRemoteSessionEntries({ host, sock, folder, sessionId, runCat }) {
+  const run = runCat || ((args) => spawnCapture('ssh', args, 'utf8'));
+  const out = await run(remoteJsonlCatArgs(host, sock, folder, sessionId));
+  const entries = [];
+  for (const line of String(out).split('\n')) {
+    if (!line.trim()) continue;
+    try { entries.push(JSON.parse(line)); } catch {}
+  }
+  return entries;
+}
+
+module.exports = {
+  parseRemoteListing,
+  cwdToDisplay,
+  diffChangedSessions,
+  decodeFramedFiles,
+  syncRemoteHost,
+  fetchRemoteSessionEntries,
+  // SSH command builders (used by main.js wiring / View messages)
+  LISTING_SCRIPT,
+  fetchScript,
+  sshCmdArgs,
+  remoteJsonlCatArgs,
+  shellSingleQuote,
+};

--- a/session-cache.js
+++ b/session-cache.js
@@ -5,6 +5,7 @@ const { getFolderIndexMtimeMs } = require('./folder-index-state');
 const { deriveProjectPath } = require('./derive-project-path');
 const { readSessionFile } = require('./read-session-file');
 const { encodeProjectPath } = require('./encode-project-path');
+const { parseRemoteProjectPath } = require('./remote-hosts');
 
 /**
  * Session cache module.
@@ -187,6 +188,10 @@ function buildProjectsFromCache(showArchived) {
     if (!row.projectPath) continue;
     if (hiddenProjects.has(row.projectPath)) continue;
     const meta = metaMap.get(row.sessionId);
+    // Phase 2: remote rows (source != null) carry a synthetic ssh://<label>/<dir>
+    // projectPath. Derive the host/dir straight from it so a whole host's sessions
+    // auto-group by directory even when the dir was never explicitly registered.
+    const parsedRemote = row.source ? parseRemoteProjectPath(row.projectPath) : null;
     const s = {
       sessionId: row.sessionId,
       summary: row.summary,
@@ -200,14 +205,29 @@ function buildProjectsFromCache(showArchived) {
       name: meta?.name || null,
       starred: meta?.starred || 0,
       archived: meta?.archived || 0,
+      // Past remote sessions render with the SSH badge + Claude logo, like live ones.
+      source: row.source || null,
+      remote: !!row.source,
+      remoteLabel: parsedRemote ? parsedRemote.hostLabel : null,
+      remoteMode: row.source ? 'claude' : null,
+      // Enough context for click-to-resume on the remote host (parity with local).
+      hostId: row.source || null,
+      remotePath: parsedRemote ? parsedRemote.remotePath : null,
     };
     if (!showArchived && s.archived) continue;
     if (!projectMap.has(row.projectPath)) {
-      projectMap.set(row.projectPath, {
+      const grp = {
         folder: encodeProjectPath(row.projectPath),
         projectPath: row.projectPath,
         sessions: [],
-      });
+      };
+      if (parsedRemote) {
+        grp.remote = true;
+        grp.hostId = row.source;
+        grp.hostLabel = parsedRemote.hostLabel;
+        grp.remotePath = parsedRemote.remotePath;
+      }
+      projectMap.set(row.projectPath, grp);
     }
     projectMap.get(row.projectPath).sessions.push(s);
   }
@@ -240,21 +260,21 @@ function buildProjectsFromCache(showArchived) {
   } catch {}
 
   // Inject persisted remote projects (Model A: a project can be local or remote).
-  // These have no local .jsonl; live sessions launched into them attach below.
+  // A group may already exist here — created above by cached remote sessions (Phase 2
+  // indexing). In that case decorate it with the remote metadata rather than skipping,
+  // otherwise it would render as a local project.
   for (const rp of (global.remoteProjects || [])) {
     if (!rp || !rp.projectPath) continue;
     if (hiddenProjects.has(rp.projectPath)) continue;
-    if (!projectMap.has(rp.projectPath)) {
-      projectMap.set(rp.projectPath, {
-        folder: encodeProjectPath(rp.projectPath),
-        projectPath: rp.projectPath,
-        sessions: [],
-        remote: true,
-        hostId: rp.hostId,
-        hostLabel: rp.hostLabel,
-        remotePath: rp.remotePath,
-      });
+    let proj = projectMap.get(rp.projectPath);
+    if (!proj) {
+      proj = { folder: encodeProjectPath(rp.projectPath), projectPath: rp.projectPath, sessions: [] };
+      projectMap.set(rp.projectPath, proj);
     }
+    proj.remote = true;
+    proj.hostId = rp.hostId;
+    proj.hostLabel = rp.hostLabel;
+    proj.remotePath = rp.remotePath;
   }
 
   // Inject active plain terminal sessions so they participate in sorting

--- a/session-cache.js
+++ b/session-cache.js
@@ -239,6 +239,24 @@ function buildProjectsFromCache(showArchived) {
     }
   } catch {}
 
+  // Inject persisted remote projects (Model A: a project can be local or remote).
+  // These have no local .jsonl; live sessions launched into them attach below.
+  for (const rp of (global.remoteProjects || [])) {
+    if (!rp || !rp.projectPath) continue;
+    if (hiddenProjects.has(rp.projectPath)) continue;
+    if (!projectMap.has(rp.projectPath)) {
+      projectMap.set(rp.projectPath, {
+        folder: encodeProjectPath(rp.projectPath),
+        projectPath: rp.projectPath,
+        sessions: [],
+        remote: true,
+        hostId: rp.hostId,
+        hostLabel: rp.hostLabel,
+        remotePath: rp.remotePath,
+      });
+    }
+  }
+
   // Inject active plain terminal sessions so they participate in sorting
   for (const [sessionId, session] of activeSessions) {
     if (session.exited || !session.isPlainTerminal) continue;
@@ -253,12 +271,17 @@ function buildProjectsFromCache(showArchived) {
     }
     const proj = projectMap.get(session.projectPath);
     if (!proj.sessions.some(s => s.sessionId === sessionId)) {
+      const remoteLabel = session.remoteHost ? session.remoteHost.label : null;
+      const summary = session.remote
+        ? ((session.remoteMode === 'shell' ? 'Shell @ ' : 'Claude @ ') + remoteLabel)
+        : 'Terminal';
       proj.sessions.push({
-        sessionId, summary: 'Terminal', firstPrompt: '', projectPath: session.projectPath,
+        sessionId, summary, firstPrompt: '', projectPath: session.projectPath,
         name: null, starred: 0, archived: 0, messageCount: 0,
         modified: new Date(session._openedAt).toISOString(),
         created: new Date(session._openedAt).toISOString(),
         type: 'terminal',
+        remote: !!session.remote, remoteLabel, remoteMode: session.remoteMode || null,
       });
     }
   }

--- a/shell-profiles.js
+++ b/shell-profiles.js
@@ -112,7 +112,7 @@ function resolveShell(profileId) {
   if (profileId && profileId !== 'auto') {
     const profiles = getShellProfiles();
     const profile = profiles.find(p => p.id === profileId);
-    if (profile && (profile.path === 'wsl.exe' || fs.existsSync(profile.path))) {
+    if (profile && (profile.path === 'wsl.exe' || isSshProfile(profile.path) || fs.existsSync(profile.path))) {
       return profile;
     }
   }
@@ -160,6 +160,18 @@ function isWslShell(shellPath) {
   return base === 'wsl.exe' || base === 'wsl';
 }
 
+// An SSH profile wraps the `ssh` command (path: 'ssh'). Detected by basename
+// so it works whether the caller passes 'ssh' or an absolute '/usr/bin/ssh'.
+function isSshProfile(shellPath) {
+  const base = path.basename(String(shellPath || '')).toLowerCase().replace(/\.exe$/, '');
+  return base === 'ssh';
+}
+
+// Single-quote a string for a POSIX shell (escaping embedded single quotes).
+function sshSingleQuote(s) {
+  return "'" + String(s).replace(/'/g, "'\\''") + "'";
+}
+
 // Returns spawn args appropriate for the resolved shell
 function shellArgs(shellPath, cmd, extraArgs) {
   const base = path.basename(shellPath).toLowerCase();
@@ -172,6 +184,16 @@ function shellArgs(shellPath, cmd, extraArgs) {
   if (isWslShell(shellPath)) {
     if (cmd) return [...(extraArgs || []), '--', 'bash', '-l', '-i', '-c', cmd];
     return [...(extraArgs || []), '--', 'bash', '-l', '-i'];
+  }
+
+  // SSH: run the command on the remote inside a login+interactive bash so the
+  // remote PATH is set up (mirrors WSL). ssh concatenates the argv after the
+  // hostname with spaces and the remote shell re-parses it, so the payload must
+  // be single-quoted to survive as one argument. extraArgs carries the ssh
+  // options and target (e.g. ['-t', 'user@host']).
+  if (isSshProfile(shellPath)) {
+    const remote = cmd || 'exec "${SHELL:-bash}" -l';
+    return [...(extraArgs || []), 'bash', '-l', '-i', '-c', sshSingleQuote(remote)];
   }
 
   if (cmd) {
@@ -188,4 +210,4 @@ function shellArgs(shellPath, cmd, extraArgs) {
   return [];
 }
 
-module.exports = { discoverShellProfiles, getShellProfiles, resolveShell, isWindows, isWslShell, windowsToWslPath, shellArgs };
+module.exports = { discoverShellProfiles, getShellProfiles, resolveShell, isWindows, isWslShell, windowsToWslPath, shellArgs, isSshProfile };

--- a/test/build-projects.test.js
+++ b/test/build-projects.test.js
@@ -1,0 +1,73 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+const sessionCache = require('../session-cache');
+
+// Empty local projects dir → only remote/injected groups appear.
+const tmpProjects = fs.mkdtempSync(path.join(os.tmpdir(), 'swb-bp-'));
+
+function initWith({ cached, global }) {
+  sessionCache.init({
+    PROJECTS_DIR: tmpProjects,
+    activeSessions: new Map(),
+    getMainWindow: () => null,
+    log: { info() {}, error() {} },
+    db: {
+      deleteCachedFolder() {}, getCachedByFolder() { return []; }, upsertCachedSessions() {}, deleteCachedSession() {},
+      deleteSearchFolder() {}, deleteSearchSession() {}, upsertSearchEntries() {},
+      setFolderMeta() {}, getAllFolderMeta() { return new Map(); },
+      getAllMeta: () => new Map(),
+      getAllCached: () => cached,
+      getSetting: (k) => (k === 'global' ? global : null),
+      getMeta: () => null,
+      setName() {},
+    },
+  });
+}
+
+const REMOTE_ROW = {
+  sessionId: 'R1', folder: '-home-u-proj', projectPath: 'ssh://gpu/~/proj',
+  summary: 'remote question', firstPrompt: 'remote question', created: 'C', modified: 'M',
+  messageCount: 2, slug: null, aiTitle: null, source: 'h1',
+};
+const REMOTE_PROJECT = { projectPath: 'ssh://gpu/~/proj', hostId: 'h1', hostLabel: 'gpu', remotePath: '~/proj' };
+
+test('cached remote rows group under the injected remote project (decorated as remote)', () => {
+  initWith({ cached: [REMOTE_ROW], global: { remoteProjects: [REMOTE_PROJECT] } });
+  const projects = sessionCache.buildProjectsFromCache(false);
+  const remote = projects.find((p) => p.projectPath === 'ssh://gpu/~/proj');
+  assert.ok(remote, 'remote project present');
+  assert.strictEqual(remote.remote, true, 'group flagged remote (not rendered as local)');
+  assert.strictEqual(remote.hostId, 'h1');
+  assert.strictEqual(remote.hostLabel, 'gpu');
+  assert.strictEqual(remote.remotePath, '~/proj');
+  assert.strictEqual(remote.sessions.length, 1, 'past remote session grouped here');
+});
+
+test('auto-discovered remote rows (no registered project) still group as remote', () => {
+  // No remoteProjects entry — the group must still be decorated from the ssh:// path.
+  const row = { ...REMOTE_ROW, sessionId: 'R9', projectPath: 'ssh://gpu/~/discovered' };
+  initWith({ cached: [row], global: { remoteProjects: [] } });
+  const projects = sessionCache.buildProjectsFromCache(false);
+  const g = projects.find((p) => p.projectPath === 'ssh://gpu/~/discovered');
+  assert.ok(g, 'auto-discovered group present');
+  assert.strictEqual(g.remote, true);
+  assert.strictEqual(g.hostId, 'h1');
+  assert.strictEqual(g.hostLabel, 'gpu');
+  assert.strictEqual(g.remotePath, '~/discovered');
+  assert.strictEqual(g.sessions[0].remoteLabel, 'gpu');
+});
+
+test('past remote sessions carry source/remote/remoteLabel for sidebar rendering', () => {
+  initWith({ cached: [REMOTE_ROW], global: { remoteProjects: [REMOTE_PROJECT] } });
+  const projects = sessionCache.buildProjectsFromCache(false);
+  const s = projects.find((p) => p.projectPath === 'ssh://gpu/~/proj').sessions[0];
+  assert.strictEqual(s.sessionId, 'R1');
+  assert.strictEqual(s.source, 'h1');
+  assert.strictEqual(s.remote, true);
+  assert.strictEqual(s.remoteLabel, 'gpu');
+  assert.notStrictEqual(s.remoteMode, 'shell'); // treated as a Claude session (SSH badge + Claude logo)
+});

--- a/test/db-migration.test.js
+++ b/test/db-migration.test.js
@@ -1,0 +1,48 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+
+// Build a pre-Phase-2 (v3) DB with the OLD schema (no source column) and a row,
+// then load db.js and confirm it migrates in place without losing data.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swb-db-mig-'));
+const dbPath = path.join(tmpDir, 'test.db');
+
+{
+  const old = new Database(dbPath);
+  old.exec(`CREATE TABLE session_cache (
+    sessionId TEXT PRIMARY KEY, folder TEXT NOT NULL, projectPath TEXT, summary TEXT,
+    firstPrompt TEXT, created TEXT, modified TEXT, messageCount INTEGER DEFAULT 0,
+    slug TEXT, aiTitle TEXT)`);
+  old.exec(`CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)`);
+  old.exec(`CREATE TABLE search_map (rowid INTEGER PRIMARY KEY, id TEXT NOT NULL, type TEXT NOT NULL, folder TEXT)`);
+  old.prepare(`INSERT INTO session_cache
+    (sessionId, folder, projectPath, summary, firstPrompt, created, modified, messageCount)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`).run('OLD1', 'F', '/p', 'sum', 'sum', 'C', 'M', 3);
+  old.prepare("INSERT INTO settings (key, value) VALUES ('db_version', ?)").run(JSON.stringify(3));
+  old.close();
+}
+
+process.env.SWITCHBOARD_DATA_DIR = tmpDir;
+process.env.SWITCHBOARD_DB_PATH = dbPath;
+const db = require('../db');
+
+test('v3→v4 migration adds source column and preserves existing rows as local', () => {
+  const rows = db.getAllCached();
+  const old = rows.find(r => r.sessionId === 'OLD1');
+  assert.ok(old, 'existing row preserved through migration');
+  assert.strictEqual(old.source, null, 'pre-existing rows are treated as local (source NULL)');
+  assert.strictEqual(old.messageCount, 3, 'existing data intact');
+});
+
+test('source-aware queries work after in-place migration', () => {
+  db.upsertCachedSessions([{
+    sessionId: 'R1', folder: 'F', projectPath: 'ssh://h/~/p', summary: 's', firstPrompt: 's',
+    created: 'C', modified: 'M2', messageCount: 1, slug: null, aiTitle: null, source: 'host-1',
+  }]);
+  assert.deepStrictEqual(db.getCachedBySource('host-1').map(r => r.sessionId), ['R1']);
+  // Local folder query still ignores the remote row sharing folder "F"
+  assert.deepStrictEqual(db.getCachedByFolder('F').map(r => r.sessionId), ['OLD1']);
+});

--- a/test/db-source.test.js
+++ b/test/db-source.test.js
@@ -1,0 +1,74 @@
+const { test, before } = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+// Point the DB at a throwaway temp file BEFORE requiring db.js.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swb-db-src-'));
+process.env.SWITCHBOARD_DATA_DIR = tmpDir;
+process.env.SWITCHBOARD_DB_PATH = path.join(tmpDir, 'test.db');
+
+const db = require('../db');
+
+const localSession = (id, folder, projectPath, modified) => ({
+  sessionId: id, folder, projectPath, summary: 's', firstPrompt: 's',
+  created: 'C', modified, messageCount: 1, slug: null, aiTitle: null,
+});
+const remoteSession = (id, folder, projectPath, modified, source) => ({
+  ...localSession(id, folder, projectPath, modified), source,
+});
+
+test('source defaults to NULL for local rows and is stored for remote rows', () => {
+  db.upsertCachedSessions([
+    localSession('L1', 'F', '/local/p', 'M1'),
+    remoteSession('R1', 'F', 'ssh://gpu/~/p', 'M2', 'host-1'),
+  ]);
+  const rows = db.getAllCached();
+  const l = rows.find(r => r.sessionId === 'L1');
+  const r = rows.find(r => r.sessionId === 'R1');
+  assert.strictEqual(l.source, null);
+  assert.strictEqual(r.source, 'host-1');
+});
+
+test('getCachedByFolder returns only local rows (source IS NULL)', () => {
+  // L1 (local) and R1 (remote) share folder "F"
+  const rows = db.getCachedByFolder('F');
+  assert.deepStrictEqual(rows.map(r => r.sessionId), ['L1']);
+});
+
+test('getCachedBySource returns remote rows for a host', () => {
+  const rows = db.getCachedBySource('host-1');
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(rows[0].sessionId, 'R1');
+  assert.strictEqual(rows[0].modified, 'M2');
+});
+
+test('deleteCachedFolder removes only local rows, leaving remote rows in the same folder', () => {
+  db.deleteCachedFolder('F');
+  const rows = db.getAllCached();
+  assert.strictEqual(rows.find(r => r.sessionId === 'L1'), undefined);
+  assert.ok(rows.find(r => r.sessionId === 'R1'), 'remote row must survive local folder delete');
+});
+
+test('search indexes both local and remote sessions; source is stored', () => {
+  db.upsertCachedSessions([
+    localSession('L2', 'G', '/local/g', 'M3'),
+    remoteSession('R2', 'H', 'ssh://gpu/~/g', 'M4', 'host-1'),
+  ]);
+  db.upsertSearchEntries([
+    { id: 'L2', type: 'session', folder: 'G', source: null, title: 'local widget', body: 'alpha' },
+    { id: 'R2', type: 'session', folder: 'H', source: 'host-1', title: 'remote widget', body: 'beta' },
+  ]);
+  const hits = db.searchByType('session', 'widget', 50).map(h => h.id).sort();
+  assert.deepStrictEqual(hits, ['L2', 'R2']);
+});
+
+test('deleteRemoteProjectCache removes only that host+project rows and their search entries', () => {
+  db.deleteRemoteProjectCache('host-1', 'ssh://gpu/~/g');
+  const rows = db.getAllCached();
+  assert.strictEqual(rows.find(r => r.sessionId === 'R2'), undefined, 'remote cache row removed');
+  assert.ok(rows.find(r => r.sessionId === 'L2'), 'unrelated local row kept');
+  const hits = db.searchByType('session', 'widget', 50).map(h => h.id);
+  assert.deepStrictEqual(hits, ['L2'], 'remote search entry removed, local kept');
+});

--- a/test/remote-index.test.js
+++ b/test/remote-index.test.js
@@ -1,0 +1,136 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  parseRemoteListing,
+  cwdToDisplay,
+  diffChangedSessions,
+  decodeFramedFiles,
+  remoteJsonlCatArgs,
+} = require('../remote-index');
+const { parseRemoteProjectPath, remoteProjectPath } = require('../remote-hosts');
+
+// --- parseRemoteListing ---
+
+test('parseRemoteListing parses path, mtime, folder, sessionId, cwd', () => {
+  const p = '/home/u/.claude/projects/-home-u-proj/aaa.jsonl';
+  const r = parseRemoteListing(`${p}\t1700000000\t"cwd":"/home/u/proj"`);
+  assert.strictEqual(r.length, 1);
+  assert.strictEqual(r[0].sessionId, 'aaa');
+  assert.strictEqual(r[0].folder, '-home-u-proj');
+  assert.strictEqual(r[0].path, p);
+  assert.strictEqual(r[0].cwd, '/home/u/proj');
+  assert.strictEqual(r[0].mtimeMs, 1700000000000);
+  assert.strictEqual(r[0].modified, new Date(1700000000000).toISOString());
+});
+
+test('parseRemoteListing skips blank lines and lines with too few fields', () => {
+  const p = '/home/u/.claude/projects/-p/x.jsonl';
+  const input = [
+    '',
+    `${p}\t1700000000\t"cwd":"/p"`,
+    '   ',
+    '/only/one/field',
+    '/two\t123',
+  ].join('\n');
+  const r = parseRemoteListing(input);
+  assert.strictEqual(r.length, 1);
+  assert.strictEqual(r[0].sessionId, 'x');
+});
+
+test('parseRemoteListing yields empty cwd when the cwd field is absent/garbage', () => {
+  const p = '/home/u/.claude/projects/-p/y.jsonl';
+  const r = parseRemoteListing(`${p}\t1700000000\t`);
+  assert.strictEqual(r.length, 1);
+  assert.strictEqual(r[0].cwd, '');
+});
+
+// --- cwdToDisplay ---
+
+test('cwdToDisplay maps home-relative cwds to ~ and leaves outside paths absolute', () => {
+  assert.strictEqual(cwdToDisplay('/home/u', '/home/u'), '~');
+  assert.strictEqual(cwdToDisplay('/home/u/proj', '/home/u'), '~/proj');
+  assert.strictEqual(cwdToDisplay('/home/u/a/b', '/home/u'), '~/a/b');
+  assert.strictEqual(cwdToDisplay('/opt/work', '/home/u'), '/opt/work');
+  assert.strictEqual(cwdToDisplay('', '/home/u'), '~');
+});
+
+// --- parseRemoteProjectPath (inverse of remoteProjectPath) ---
+
+test('parseRemoteProjectPath round-trips with remoteProjectPath', () => {
+  for (const [label, dir] of [['gpu', '~/proj'], ['web-1', '~'], ['h', '/abs/path']]) {
+    const pp = remoteProjectPath(label, dir);
+    const parsed = parseRemoteProjectPath(pp);
+    assert.strictEqual(parsed.hostLabel, label);
+    assert.strictEqual(parsed.remotePath, dir);
+  }
+  assert.strictEqual(parseRemoteProjectPath('/Users/x/proj'), null);
+});
+
+// --- diffChangedSessions ---
+
+test('diffChangedSessions detects new, changed, and vanished sessions', () => {
+  const listing = [
+    { sessionId: 'a', modified: 'M1' },
+    { sessionId: 'b', modified: 'M2' },
+    { sessionId: 'c', modified: 'M3' },
+  ];
+  const cached = [
+    { sessionId: 'a', modified: 'M1' },   // unchanged
+    { sessionId: 'b', modified: 'OLD' },  // changed
+    { sessionId: 'd', modified: 'X' },    // vanished
+  ];
+  const r = diffChangedSessions(listing, cached);
+  assert.deepStrictEqual(r.toFetch.map(e => e.sessionId).sort(), ['b', 'c']);
+  assert.deepStrictEqual(r.toDelete, ['d']);
+});
+
+// --- decodeFramedFiles ---
+
+test('decodeFramedFiles splits by byte length, immune to marker in content', () => {
+  const c1 = 'line1\nline2\n';
+  const c2 = 'SWBF 99 /fake.jsonl\ninner\n'; // content that looks like a header
+  const buf = Buffer.concat([
+    Buffer.from(`SWBF ${Buffer.byteLength(c1)} /a.jsonl\n`), Buffer.from(c1),
+    Buffer.from(`SWBF ${Buffer.byteLength(c2)} /b.jsonl\n`), Buffer.from(c2),
+  ]);
+  const r = decodeFramedFiles(buf);
+  assert.strictEqual(r.length, 2);
+  assert.strictEqual(r[0].path, '/a.jsonl');
+  assert.strictEqual(r[0].content, c1);
+  assert.strictEqual(r[1].path, '/b.jsonl');
+  assert.strictEqual(r[1].content, c2);
+});
+
+test('decodeFramedFiles handles multibyte content by byte length', () => {
+  const c = 'héllo✓ world\n';
+  const buf = Buffer.concat([
+    Buffer.from(`SWBF ${Buffer.byteLength(c)} /m.jsonl\n`), Buffer.from(c),
+  ]);
+  const r = decodeFramedFiles(buf);
+  assert.strictEqual(r.length, 1);
+  assert.strictEqual(r[0].content, c);
+});
+
+// --- remoteJsonlCatArgs (live View messages) ---
+
+test('remoteJsonlCatArgs builds a BatchMode cat over the control socket with a safe path', () => {
+  const host = { source: 'config', alias: 'gpu', id: 'h1' };
+  const args = remoteJsonlCatArgs(host, '/tmp/s.sock', '-home-u-proj', 'R1');
+  assert.ok(args.includes('gpu'), 'targets the host alias');
+  assert.ok(args.some(a => a === 'BatchMode=yes'), 'never blocks on a prompt');
+  const cmd = args[args.length - 1];
+  assert.strictEqual(cmd, `cat "$HOME/.claude/projects/"'-home-u-proj'/'R1'.jsonl`);
+});
+
+test('decodeFramedFiles ignores an incomplete trailing frame and empty input', () => {
+  assert.deepStrictEqual(decodeFramedFiles(Buffer.from('')), []);
+  const c1 = 'ok\n';
+  const buf = Buffer.concat([
+    Buffer.from(`SWBF ${Buffer.byteLength(c1)} /a.jsonl\n`), Buffer.from(c1),
+    Buffer.from('SWBF 500 /truncated.jsonl\nonly a little'), // claims 500 bytes, has few
+  ]);
+  const r = decodeFramedFiles(buf);
+  assert.strictEqual(r.length, 1);
+  assert.strictEqual(r[0].path, '/a.jsonl');
+});

--- a/test/remote-ssh.test.js
+++ b/test/remote-ssh.test.js
@@ -1,0 +1,260 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { isSshProfile, shellArgs } = require('../shell-profiles');
+const {
+  parseSshConfig,
+  quoteRemoteDir,
+  buildRemoteCommand,
+  hostTargetArgs,
+  sshArgsForHost,
+  buildSshProfile,
+  testConnectionArgs,
+  remoteProjectPath,
+  classifyConnResult,
+  controlArgs,
+  parseLsDirs,
+  browseArgs,
+  normalizeManualHost,
+  buildSshConfigEntry,
+} = require('../remote-hosts');
+
+// --- isSshProfile ---
+
+test('isSshProfile recognizes ssh by basename', () => {
+  assert.equal(isSshProfile('ssh'), true);
+  assert.equal(isSshProfile('/usr/bin/ssh'), true);
+  assert.equal(isSshProfile('ssh.exe'), true);
+});
+
+test('isSshProfile rejects non-ssh shells', () => {
+  assert.equal(isSshProfile('/bin/bash'), false);
+  assert.equal(isSshProfile('wsl.exe'), false);
+  assert.equal(isSshProfile(''), false);
+  assert.equal(isSshProfile(undefined), false);
+});
+
+// --- shellArgs SSH branch ---
+
+test('shellArgs wraps a remote command as a single-quoted bash -l -i -c payload', () => {
+  const args = shellArgs('ssh', 'exec claude', ['-t', 'myhost']);
+  assert.deepEqual(args, ['-t', 'myhost', 'bash', '-l', '-i', '-c', "'exec claude'"]);
+});
+
+test('shellArgs without a command opens a remote login shell', () => {
+  const args = shellArgs('ssh', undefined, ['-t', 'myhost']);
+  assert.deepEqual(args, ['-t', 'myhost', 'bash', '-l', '-i', '-c', `'exec "\${SHELL:-bash}" -l'`]);
+});
+
+test('shellArgs single-quotes a remote command containing spaces and quotes', () => {
+  const args = shellArgs('ssh', "cd $HOME/'a b' && exec claude", ['-t', 'h']);
+  // inner single quotes must be escaped as '\'' so the whole payload survives as one arg
+  assert.equal(args[args.length - 1], `'cd $HOME/'\\''a b'\\'' && exec claude'`);
+});
+
+// --- parseSshConfig ---
+
+test('parseSshConfig parses hosts and skips wildcards', () => {
+  const cfg = [
+    'Host prod',
+    '    HostName prod.example.com',
+    '    User deploy',
+    '    Port 2222',
+    '',
+    'Host *',
+    '    ForwardAgent yes',
+    '',
+    'Host bastion',
+    '    HostName 10.0.0.1',
+  ].join('\n');
+  const hosts = parseSshConfig(cfg);
+  assert.equal(hosts.length, 2);
+  const prod = hosts.find(h => h.alias === 'prod');
+  assert.equal(prod.hostName, 'prod.example.com');
+  assert.equal(prod.user, 'deploy');
+  assert.equal(prod.port, 2222);
+  assert.equal(prod.source, 'config');
+  const bastion = hosts.find(h => h.alias === 'bastion');
+  assert.equal(bastion.hostName, '10.0.0.1');
+  assert.equal(bastion.user, undefined);
+});
+
+test('parseSshConfig de-duplicates repeated aliases (first wins)', () => {
+  const cfg = [
+    'Host dup',
+    '  HostName a.example.com',
+    'Host other',
+    '  HostName o.example.com',
+    'Host dup',
+    '  HostName b.example.com',
+  ].join('\n');
+  const hosts = parseSshConfig(cfg);
+  assert.equal(hosts.filter(h => h.alias === 'dup').length, 1);
+  assert.equal(hosts.find(h => h.alias === 'dup').hostName, 'a.example.com');
+  assert.equal(hosts.length, 2);
+});
+
+test('parseSshConfig handles key=value and multiple aliases', () => {
+  const cfg = [
+    'Host web1 web2',
+    '  HostName=example.com',
+    '  User=root',
+  ].join('\n');
+  const hosts = parseSshConfig(cfg);
+  assert.deepEqual(hosts.map(h => h.alias).sort(), ['web1', 'web2']);
+  assert.equal(hosts[0].hostName, 'example.com');
+  assert.equal(hosts[0].user, 'root');
+});
+
+// --- quoteRemoteDir ---
+
+test('quoteRemoteDir expands leading tilde to $HOME and quotes the rest', () => {
+  assert.equal(quoteRemoteDir('~'), '$HOME');
+  assert.equal(quoteRemoteDir('~/foo'), "$HOME/'foo'");
+  assert.equal(quoteRemoteDir('/a b'), "'/a b'");
+  assert.equal(quoteRemoteDir("/x'y"), "'/x'\\''y'");
+});
+
+// --- buildRemoteCommand ---
+
+test('buildRemoteCommand (claude) skips cd for home and cds otherwise', () => {
+  assert.equal(buildRemoteCommand('claude', '~', 'claude'), 'exec claude');
+  assert.equal(
+    buildRemoteCommand('claude', '/proj', 'claude --dangerously-skip-permissions'),
+    "cd '/proj' && exec claude --dangerously-skip-permissions"
+  );
+  assert.equal(buildRemoteCommand('claude', '~/work', 'claude'), "cd $HOME/'work' && exec claude");
+});
+
+test('buildRemoteCommand (shell) execs the login shell, tolerating a failed cd', () => {
+  assert.equal(buildRemoteCommand('shell', '~', null), 'exec "${SHELL:-bash}" -l');
+  assert.equal(
+    buildRemoteCommand('shell', '/proj', null),
+    `cd '/proj' 2>/dev/null; exec "\${SHELL:-bash}" -l`
+  );
+});
+
+// --- host -> ssh args ---
+
+test('hostTargetArgs uses the alias for config hosts', () => {
+  assert.deepEqual(hostTargetArgs({ source: 'config', alias: 'prod' }), ['prod']);
+});
+
+test('hostTargetArgs builds user@host and passes a non-default port before the target', () => {
+  assert.deepEqual(
+    hostTargetArgs({ source: 'manual', host: '1.2.3.4', user: 'bob', port: 22 }),
+    ['bob@1.2.3.4']
+  );
+  assert.deepEqual(
+    hostTargetArgs({ source: 'manual', host: '1.2.3.4', user: 'bob', port: 2222 }),
+    ['-p', '2222', 'bob@1.2.3.4']
+  );
+  assert.deepEqual(hostTargetArgs({ source: 'manual', host: '1.2.3.4' }), ['1.2.3.4']);
+});
+
+test('hostTargetArgs injects identity file and extra -o options (manual), options before target', () => {
+  const host = {
+    source: 'manual', host: 'h', user: 'u', port: 2222,
+    identityFile: '/keys/id_rsa',
+    options: ['HostKeyAlgorithms=+ssh-rsa', 'PreferredAuthentications=password'],
+  };
+  assert.deepEqual(hostTargetArgs(host), [
+    '-o', 'HostKeyAlgorithms=+ssh-rsa',
+    '-o', 'PreferredAuthentications=password',
+    '-i', '/keys/id_rsa',
+    '-p', '2222',
+    'u@h',
+  ]);
+  // target is last
+  assert.equal(hostTargetArgs(host).slice(-1)[0], 'u@h');
+});
+
+test('normalizeManualHost parses options from a string and trims identity file', () => {
+  const h = normalizeManualHost({ host: 'h', user: 'u', identityFile: ' ~/.ssh/k ', options: 'HostKeyAlgorithms=+ssh-rsa\nPreferredAuthentications=password , Ciphers=aes128-ctr' });
+  assert.equal(h.identityFile, '~/.ssh/k');
+  assert.deepEqual(h.options, ['HostKeyAlgorithms=+ssh-rsa', 'PreferredAuthentications=password', 'Ciphers=aes128-ctr']);
+  // already-array options pass through
+  assert.deepEqual(normalizeManualHost({ host: 'h', options: ['A=1'] }).options, ['A=1']);
+});
+
+test('buildSshConfigEntry emits a valid Host block (Key Value, not Key=Value)', () => {
+  const entry = buildSshConfigEntry({ label: 'prod', host: 'prod.example.com', user: 'deploy', port: 2222, identityFile: '~/.ssh/id', options: ['HostKeyAlgorithms=+ssh-rsa'] });
+  assert.match(entry, /^Host prod$/m);
+  assert.match(entry, /^\s+HostName prod\.example\.com$/m);
+  assert.match(entry, /^\s+User deploy$/m);
+  assert.match(entry, /^\s+Port 2222$/m);
+  assert.match(entry, /^\s+IdentityFile ~\/\.ssh\/id$/m);
+  assert.match(entry, /^\s+HostKeyAlgorithms \+ssh-rsa$/m);
+  assert.doesNotMatch(entry, /=/); // config uses space-separated, never Key=Value
+});
+
+test('sshArgsForHost forces a PTY with -t before the target', () => {
+  assert.deepEqual(sshArgsForHost({ source: 'config', alias: 'prod' }), ['-t', 'prod']);
+  assert.deepEqual(
+    sshArgsForHost({ source: 'manual', host: 'h', user: 'u', port: 2200 }),
+    ['-t', '-p', '2200', 'u@h']
+  );
+});
+
+test('buildSshProfile produces an ssh shell profile', () => {
+  const host = { id: 'config:prod', label: 'prod', source: 'config', alias: 'prod' };
+  const p = buildSshProfile(host);
+  assert.equal(p.id, 'ssh:config:prod');
+  assert.equal(p.path, 'ssh');
+  assert.equal(p.remote, true);
+  assert.deepEqual(p.args, ['-t', 'prod']);
+  assert.equal(p.remoteHost, host);
+  assert.match(p.name, /prod/);
+});
+
+test('remoteProjectPath builds a stable synthetic path per host+dir', () => {
+  assert.equal(remoteProjectPath('mi300-7', '~/proj'), 'ssh://mi300-7/~/proj');
+  assert.equal(remoteProjectPath('ce-master', '~'), 'ssh://ce-master/~');
+  // default dir when omitted
+  assert.equal(remoteProjectPath('h', ''), 'ssh://h/~');
+});
+
+test('classifyConnResult distinguishes reachable/auth/hostkey/unreachable', () => {
+  assert.equal(classifyConnResult(0, '').status, 'ok');
+  assert.equal(classifyConnResult(255, 'user@h: Permission denied (publickey,password).').status, 'auth');
+  assert.equal(classifyConnResult(255, 'Host key verification failed.').status, 'hostkey');
+  assert.equal(classifyConnResult(255, 'ssh: connect to host h port 22: Connection refused').status, 'unreachable');
+  assert.equal(classifyConnResult(255, 'ssh: Could not resolve hostname h: nodename nor servname provided').status, 'unreachable');
+  assert.equal(classifyConnResult(255, 'Operation timed out').status, 'unreachable');
+  // reachable statuses mean the host answered; unreachable means it did not
+  assert.equal(classifyConnResult(255, 'Permission denied (publickey,password).').reachable, true);
+  assert.equal(classifyConnResult(255, 'Connection refused').reachable, false);
+});
+
+test('controlArgs enables connection multiplexing on a socket path', () => {
+  assert.deepEqual(controlArgs('/tmp/swb-ab12.sock'), [
+    '-o', 'ControlMaster=auto', '-o', 'ControlPath=/tmp/swb-ab12.sock', '-o', 'ControlPersist=600',
+  ]);
+});
+
+test('parseLsDirs keeps only directories (ls -1Ap trailing slash), stripped and sorted', () => {
+  const out = 'file.txt\nprojects/\n.config/\nreadme.md\nsrc/\n';
+  assert.deepEqual(parseLsDirs(out), ['.config', 'projects', 'src']);
+  assert.deepEqual(parseLsDirs(''), []);
+  assert.deepEqual(parseLsDirs('onlyfile.txt\n'), []);
+});
+
+test('browseArgs lists a remote dir over the control socket, options before target', () => {
+  const args = browseArgs({ source: 'config', alias: 'prod' }, '/tmp/swb-x.sock', '~/work');
+  // all -o options and the target precede the remote ls command (last element)
+  assert.equal(args[args.length - 1], "ls -1Ap -- $HOME/'work'");
+  assert.ok(args.includes('prod'));
+  assert.ok(args.includes('BatchMode=yes'));
+  assert.ok(args.includes('ControlPath=/tmp/swb-x.sock'));
+  // target must come before the command
+  assert.ok(args.indexOf('prod') < args.length - 1);
+});
+
+test('testConnectionArgs uses BatchMode and a short timeout, no PTY', () => {
+  assert.deepEqual(testConnectionArgs({ source: 'config', alias: 'prod' }), [
+    '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8', 'prod', 'true',
+  ]);
+  assert.deepEqual(testConnectionArgs({ source: 'manual', host: 'h', user: 'u', port: 2200 }), [
+    '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=8', '-p', '2200', 'u@h', 'true',
+  ]);
+});

--- a/test/remote-sync.test.js
+++ b/test/remote-sync.test.js
@@ -1,0 +1,76 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+// Temp DB (needs the Electron-built better-sqlite3 → run via `npm test`).
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swb-sync-'));
+process.env.SWITCHBOARD_DATA_DIR = tmpDir;
+process.env.SWITCHBOARD_DB_PATH = path.join(tmpDir, 'test.db');
+const db = require('../db');
+
+const { syncRemoteHost } = require('../remote-index');
+
+const userMsg = (t, ts) => JSON.stringify({ type: 'user', timestamp: ts, message: { role: 'user', content: t } });
+const asstMsg = (t, ts) => JSON.stringify({ type: 'assistant', timestamp: ts, message: { role: 'assistant', content: [{ type: 'text', text: t }] } });
+
+const HOST = { id: 'h1', label: 'gpu' };
+const PROJ_A = '/home/u/.claude/projects/-home-u-proj-a/S1.jsonl';
+const PROJ_B = '/home/u/.claude/projects/-home-u-proj-b/S2.jsonl';
+const CONTENT = {
+  [PROJ_A]: [userMsg('work on A', '2026-01-01T00:00:00Z'), asstMsg('ok', '2026-01-01T00:01:00Z')].join('\n'),
+  [PROJ_B]: [userMsg('work on B', '2026-01-02T00:00:00Z'), asstMsg('ok', '2026-01-02T00:01:00Z')].join('\n'),
+};
+
+function fakeRunners(listingLines) {
+  return {
+    runText: async () => listingLines.join('\n'),
+    runRaw: async (_kind, paths) => {
+      const parts = [];
+      for (const p of paths) {
+        if (CONTENT[p]) parts.push(Buffer.from(`SWBF ${Buffer.byteLength(CONTENT[p])} ${p}\n`), Buffer.from(CONTENT[p]));
+      }
+      return Buffer.concat(parts);
+    },
+  };
+}
+
+test('syncRemoteHost auto-discovers ALL sessions on the host, grouped by cwd', async () => {
+  const listing = [
+    `${PROJ_A}\t1700000000\t"cwd":"/home/u/proj-a"`,
+    `${PROJ_B}\t1700000100\t"cwd":"/home/u/proj-b"`,
+  ];
+  const { runText, runRaw } = fakeRunners(listing);
+  const res = await syncRemoteHost({ host: HOST, sock: '/tmp/s', db, runText, runRaw });
+  assert.strictEqual(res.indexed, 2, 'both sessions indexed with no registered projects');
+
+  const rows = db.getAllCached();
+  const s1 = rows.find(r => r.sessionId === 'S1');
+  const s2 = rows.find(r => r.sessionId === 'S2');
+  assert.strictEqual(s1.source, 'h1');
+  assert.strictEqual(s1.projectPath, 'ssh://gpu/~/proj-a', 'cwd → ~/proj-a project path');
+  assert.strictEqual(s2.projectPath, 'ssh://gpu/~/proj-b', 'cwd → ~/proj-b project path');
+  assert.strictEqual(s1.summary, 'work on A');
+
+  assert.ok(db.searchByType('session', 'work on B', 50).some(h => h.id === 'S2'), 'remote sessions searchable');
+});
+
+test('syncRemoteHost prunes sessions that vanished from the host', async () => {
+  // Only proj-a remains in the listing now; S2 should be removed.
+  const { runText, runRaw } = fakeRunners([`${PROJ_A}\t1700000000\t"cwd":"/home/u/proj-a"`]);
+  const res = await syncRemoteHost({ host: HOST, sock: '/tmp/s', db, runText, runRaw });
+  assert.strictEqual(res.deleted, 1);
+  assert.strictEqual(db.getAllCached().find(r => r.sessionId === 'S2'), undefined);
+  assert.strictEqual(db.searchByType('session', 'work on B', 50).length, 0);
+});
+
+test('syncRemoteHost skips sessions with no cwd', async () => {
+  const NOCWD = '/home/u/.claude/projects/-home-u-x/S9.jsonl';
+  const { runText, runRaw } = fakeRunners([
+    `${PROJ_A}\t1700000000\t"cwd":"/home/u/proj-a"`,
+    `${NOCWD}\t1700000200\t`,
+  ]);
+  await syncRemoteHost({ host: HOST, sock: '/tmp/s', db, runText, runRaw });
+  assert.strictEqual(db.getAllCached().find(r => r.sessionId === 'S9'), undefined);
+});

--- a/test/session-parse.test.js
+++ b/test/session-parse.test.js
@@ -1,0 +1,90 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { parseSessionContent } = require('../read-session-file');
+
+const userMsg = (text, ts) =>
+  JSON.stringify({ type: 'user', timestamp: ts, message: { role: 'user', content: text } });
+const asstMsg = (text, ts) =>
+  JSON.stringify({ type: 'assistant', timestamp: ts, message: { role: 'assistant', content: [{ type: 'text', text }] } });
+
+const META = { sessionId: 's1', folder: 'f', projectPath: '/p' };
+
+test('parses summary, messageCount, textContent from basic content', () => {
+  const content = [
+    userMsg('Fix the login bug', '2026-07-10T10:00:00Z'),
+    asstMsg('Sure, let me look', '2026-07-10T10:00:05Z'),
+  ].join('\n');
+  const r = parseSessionContent(content, { ...META, created: 'C', modified: 'M' });
+  assert.strictEqual(r.summary, 'Fix the login bug');
+  assert.strictEqual(r.firstPrompt, 'Fix the login bug');
+  assert.strictEqual(r.messageCount, 2);
+  assert.strictEqual(r.created, 'C');
+  assert.strictEqual(r.modified, 'M');
+  assert.strictEqual(r.sessionId, 's1');
+  assert.strictEqual(r.folder, 'f');
+  assert.strictEqual(r.projectPath, '/p');
+  assert.ok(r.textContent.includes('Fix the login bug'));
+  assert.ok(r.textContent.includes('Sure, let me look'));
+});
+
+test('skips local-command messages when choosing the summary', () => {
+  const content = [
+    userMsg('<bash-input>ls</bash-input>', '2026-07-10T10:00:00Z'),
+    userMsg('Real first question', '2026-07-10T10:00:01Z'),
+    asstMsg('ok', '2026-07-10T10:00:02Z'),
+  ].join('\n');
+  const r = parseSessionContent(content, { ...META, created: 'C', modified: 'M' });
+  assert.strictEqual(r.summary, 'Real first question');
+  assert.strictEqual(r.messageCount, 3);
+});
+
+test('extracts slug, customTitle, and aiTitle', () => {
+  const content = [
+    JSON.stringify({ type: 'user', slug: 'my-slug', message: { role: 'user', content: 'hi' } }),
+    JSON.stringify({ type: 'custom-title', customTitle: 'My Title' }),
+    JSON.stringify({ type: 'ai-title', aiTitle: 'AI Title' }),
+    asstMsg('response', '2026-07-10T10:00:02Z'),
+  ].join('\n');
+  const r = parseSessionContent(content, { ...META, created: 'C', modified: 'M' });
+  assert.strictEqual(r.slug, 'my-slug');
+  assert.strictEqual(r.customTitle, 'My Title');
+  assert.strictEqual(r.aiTitle, 'AI Title');
+  assert.strictEqual(r.messageCount, 2);
+  assert.strictEqual(r.summary, 'hi');
+});
+
+test('derives created/modified from entry timestamps when meta omits them', () => {
+  const content = [
+    userMsg('Q', '2026-01-01T00:00:00Z'),
+    asstMsg('A', '2026-01-02T00:00:00Z'),
+  ].join('\n');
+  const r = parseSessionContent(content, { ...META });
+  assert.strictEqual(r.created, '2026-01-01T00:00:00Z');
+  assert.strictEqual(r.modified, '2026-01-02T00:00:00Z');
+});
+
+test('meta created/modified take precedence over entry timestamps', () => {
+  const content = [
+    userMsg('Q', '2026-01-01T00:00:00Z'),
+    asstMsg('A', '2026-01-02T00:00:00Z'),
+  ].join('\n');
+  const r = parseSessionContent(content, { ...META, created: 'EXPLICIT_C', modified: 'EXPLICIT_M' });
+  assert.strictEqual(r.created, 'EXPLICIT_C');
+  assert.strictEqual(r.modified, 'EXPLICIT_M');
+});
+
+test('returns null when there is no usable summary or no messages', () => {
+  assert.strictEqual(parseSessionContent('', { ...META }), null);
+  const onlyTitle = JSON.stringify({ type: 'custom-title', customTitle: 'x' });
+  assert.strictEqual(parseSessionContent(onlyTitle, { ...META }), null);
+});
+
+test('uses scheduled-task name as summary when present', () => {
+  const content = [
+    userMsg('<scheduled-task name="nightly backup">run it</scheduled-task>', '2026-01-01T00:00:00Z'),
+    asstMsg('done', '2026-01-01T00:01:00Z'),
+  ].join('\n');
+  const r = parseSessionContent(content, { ...META, created: 'C', modified: 'M' });
+  assert.strictEqual(r.summary, 'Scheduled: nightly backup');
+});


### PR DESCRIPTION
## Summary

**Phase 2 of remote SSH support.** Phase 1 (#76) let you *launch* Claude/shell on remote hosts, but remote sessions appeared in the sidebar only while live. This PR indexes a connected host's **past** sessions so they persist across restarts, are **searchable**, and **resume in a terminal** — reaching local parity. **No transcript is copied to your local disk**; everything is read on demand over the existing SSH connection.

> ⚠️ **Stacks on #76.** This branch builds on the Phase 1 branch, so until #76 merges this PR's diff includes #76's changes. Please merge #76 first; the Phase-2-only work is the final commit.

> Screenshots use redacted demo hosts (`gpu-server`, `build-box`, `*.example.com`); no real infrastructure is shown.

Past remote sessions now persist in the sidebar — grouped by remote directory, each with the SSH badge, the Claude logo, and a ⟳ refresh control (local projects, e.g. `dev/webapp`, have neither):

<img width="380" alt="Remote sessions grouped in the sidebar" src="https://raw.githubusercontent.com/HAN-oQo/switchboard/pr-assets/screenshots/phase2-1-remote-sidebar.png">

Full-text search covers remote transcripts too — here `memory` matches two remote sessions by their synced content, not just titles:

<img width="380" alt="Searching remote sessions" src="https://raw.githubusercontent.com/HAN-oQo/switchboard/pr-assets/screenshots/phase2-2-search-remote.png">

## What's new

- **Auto-discovery** — connect a host and every past session on it appears, grouped by its remote directory (`ssh://<host>/<dir>`). No per-directory registration needed.
- **Search** — remote sessions are indexed into the existing FTS table (tagged with a new `source` column) and show up in search alongside local ones.
- **Persistence** — indexed remote sessions survive app restarts (served from the local cache DB); a background sweep re-syncs reachable hosts on launch.
- **Click-to-resume** — clicking a remote session resumes it in a terminal (`cd <dir> && claude --resume "<id>"` on the host), same UX as local. Fork supported. Remote Control reconnects automatically on resume when the session had it.
- **View messages** — reads the remote transcript live over SSH (no local copy); prompts to connect when offline.
- **Refresh (⟳)** on remote project headers; status-bar feedback for sync results.

## How it works

- **Transport**: metadata-over-SSH sync over the Phase 1 ControlMaster socket (`remote-index.js`). Lists `~/.claude/projects/*.jsonl`, derives a project per session from its `cwd`, fetches only new/changed transcripts via a length-framed stream, parses them in memory with the shared `parseSessionContent` (extracted from `read-session-file.js`, identical to local behavior), and upserts into the cache + FTS with `source = <host>`. Vanished sessions are pruned.
- **DB**: additive migration adds a `source` column to `session_cache` and `search_map` (`NULL` = local — no cache wipe). All folder-scoped queries are source-isolated so local and remote rows never collide.
- **No local mirror**: transcripts are never written to disk; "View messages" and resume read the remote host directly (source of truth).

## Testing

- **56 unit tests** (`npm test`, run under Electron's node to match the app's `better-sqlite3` ABI): JSONL parsing, the SSH listing/framing/diff/cwd parsers, the `source` migration + source-isolation, sync orchestration (SSH runners injected), and sidebar grouping.
- The v3→v4 migration was verified against a copy of a real DB (34 sessions preserved, `source` backfilled to local).
- Manual: connect → past sessions appear + searchable → restart shows them from cache → click resumes on the host → View messages streams live.

## Roadmap

Remote SSH support ships in phases, ordered by effort‑to‑value — each is independently useful and lands as its own PR. **This PR is Phase 2.**

- [x] **Phase 1 — Remote sessions & host management** (#76): launch Claude/shell on remote hosts; remote hosts + directories as first‑class projects; interactive Connect; remote directory Browse; host config (import, manual add, identity/options, write‑to‑`~/.ssh/config`).
- [x] **Phase 2 — Indexing, search & resume** *(this PR)*: index a connected host's **past** sessions (metadata over the existing SSH connection — no transcript copied to disk) so they persist in the sidebar, are **searchable**, and **resume/fork** in a terminal on the host. Adds a `source` column to the cache/search tables.
- [ ] **Phase 3 — IDE emulation over SSH**: reverse‑forward the IDE MCP socket (`ssh -R`) so remote proposed diffs / file opens land in Switchboard's side panel (behind a setting).

**Why this order:** Phase 1 delivers the core "run Claude Code on my server" value with the least new machinery (reuses the `node‑pty` + shell‑profile path, mirroring how WSL is modeled); Phase 2 unlocks history, search, and resume; Phase 3 adds richer IDE workflows. Nothing later blocks shipping this one.

*(Remote Control — `claude --remote-control` for live cross-device mirroring — is orthogonal to local-vs-remote and is tracked separately, not part of this roadmap.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
