### PR TITLE
Fix text selection in mouse-tracking sessions on macOS

### DIFF
--- a/public/terminal-manager.js
+++ b/public/terminal-manager.js
@@ -179,6 +179,13 @@ function createTerminalEntry(session) {
     scrollback: 10000,
     convertEol: true,
     allowProposedApi: true,
+    // A TUI that turns on full mouse tracking (CSI ?1003h) makes xterm forward every
+    // drag to the application, so normal text selection is dead. Terminal.app and
+    // iTerm2 let you hold Option to override that; xterm.js requires opting in.
+    // Without this, selecting (and therefore copying) inside such a session is
+    // impossible on macOS and Cmd+C silently leaves the previous clipboard contents
+    // in place. Windows/Linux get the same escape hatch via Shift, which needs no flag.
+    macOptionClickForcesSelection: true,
     linkHandler: {
       activate: (_event, uri) => {
         if (uri.startsWith('file://') && typeof openFileInPanel === 'function') {


### PR DESCRIPTION
## Problem

Text cannot be selected with the mouse on macOS in any session running a TUI that enables mouse tracking, which makes copying impossible.

When an application turns on mouse tracking (`CSI ?1002h` / `CSI ?1003h`), xterm.js forwards every drag to that application instead of starting a selection. Terminal.app and iTerm2 let you hold <kbd>Option</kbd> to override the convention, but xterm.js gates the same escape hatch behind `macOptionClickForcesSelection`, which defaults to `false` and was never set here.

The symptom users report is misleading. `Cmd+C` finds no selection, so xterm's copy handler is a no-op and it fails **silently** — the previous clipboard contents stay in place. The next paste then inserts stale text, which reads as "paste is broken" even though the paste path itself is fine.

## Reproduction

Measured against the live renderer over the Chrome DevTools Protocol, driving synthetic mouse and key events. The session runs `vim -c "set mouse=a"` on a file containing one known line:

```
mouseTrackingMode = "drag"

[option OFF] plain drag  -> ""
[option OFF] Option+drag -> ""

[option ON]  plain drag  -> ""
[option ON]  Option+drag -> "the quick brown fox jumps over the lazy dog"

clipboard after Cmd+C    =  "the quick brown fox jumps over the lazy dog"
```

Same gesture, same session, only the option toggled — which isolates the cause. Plain drag correctly keeps going to the application in both states, so mouse-driven TUIs stay usable.

## Fix

One option on the xterm instance in `public/terminal-manager.js`:

```js
macOptionClickForcesSelection: true,
```

Windows and Linux were never affected — there `shouldForceSelection` keys off <kbd>Shift</kbd>, which needs no option.

## Verification

- Full round trip in a mouse-tracking session: <kbd>Option</kbd>+drag → `Cmd+C` → `Cmd+V` returns the selected line intact.
- No regression in sessions without mouse tracking: plain drag, Option+drag, double-click (one word) and triple-click (full line) all behave as before.
- `npm test` passes, `npm run bundle:codemirror` succeeds.

## Trade-off

Enabling this flag disables <kbd>Option</kbd>+drag rectangular (column) selection on macOS, since xterm's `shouldColumnSelect` and `shouldForceSelection` share the same modifier. This is the standard trade-off and matches iTerm2's default behaviour.

## Related

Distinct from #54 / #55, which cover copy on Linux/Wayland via OSC 52. Worth noting separately that Switchboard doesn't handle OSC 52 at all, so an application's own clipboard requests are dropped — out of scope here.
