### PR TITLE
fix: shorten project paths correctly on Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -668,8 +668,10 @@ ipcMain.handle('get-memories', () => {
         if (projectPath && hiddenProjects.has(projectPath)) continue;
 
         // Use same 2-deep short path as Sessions tab (e.g. "dev/MyClaude")
+        // Splits on both separators — `cwd` is backslash-separated on Windows,
+        // where splitting on '/' alone left the whole path as one segment.
         const shortName = projectPath
-          ? projectPath.split('/').filter(Boolean).slice(-2).join('/')
+          ? projectPath.split(/[\\/]/).filter(Boolean).slice(-2).join('/')
           : folderToShortPath(folder);
         const files = [];
         const seenPaths = new Set();

--- a/public/app.js
+++ b/public/app.js
@@ -484,7 +484,7 @@ searchInput.addEventListener('input', () => {
         if (searchTitlesOnly) {
           const lowerQ = query.toLowerCase();
           for (const p of cachedAllProjects) {
-            const shortName = p.projectPath.split('/').filter(Boolean).slice(-2).join('/');
+            const shortName = shortProjectPath(p.projectPath);
             if (shortName.toLowerCase().includes(lowerQ)) {
               if (!searchMatchProjectPaths) searchMatchProjectPaths = new Set();
               searchMatchProjectPaths.add(p.projectPath);

--- a/public/dialogs.js
+++ b/public/dialogs.js
@@ -198,7 +198,7 @@ async function showNewSessionDialog(project) {
   }
 
   dialog.innerHTML = `
-    <h3>New Session — ${escapeHtml(project.projectPath.split('/').filter(Boolean).slice(-2).join('/'))}</h3>
+    <h3>New Session — ${escapeHtml(shortProjectPath(project.projectPath))}</h3>
     <div class="settings-field">
       <div class="settings-label">Permission Mode</div>
       <div class="permission-grid" id="nsd-mode-grid">${renderModeGrid()}</div>

--- a/public/grid-view.js
+++ b/public/grid-view.js
@@ -17,7 +17,7 @@ function wrapInGridCard(sessionId) {
   if (!session || !entry) return;
 
   const displayName = cleanDisplayName(session.name || session.aiTitle || session.summary) || sessionId;
-  const shortProject = session.projectPath ? session.projectPath.split('/').filter(Boolean).slice(-2).join('/') : '';
+  const shortProject = shortProjectPath(session.projectPath);
 
   // Create card wrapper
   const card = document.createElement('div');
@@ -77,7 +77,7 @@ function wrapInGridCard(sessionId) {
       targetHeading = document.createElement('div');
       targetHeading.className = 'grid-project-heading';
       targetHeading.dataset.projectPath = pp;
-      targetHeading.textContent = pp ? pp.split('/').filter(Boolean).slice(-2).join('/') : 'Other';
+      targetHeading.textContent = pp ? shortProjectPath(pp) : 'Other';
       // Insert heading in sortedOrder position
       const orderIndex = new Map(sortedOrder.map((e, i) => [e.projectPath, i]));
       const myIdx = orderIndex.get(pp);
@@ -223,7 +223,7 @@ function showGridView() {
       const heading = document.createElement('div');
       heading.className = 'grid-project-heading';
       heading.dataset.projectPath = projectPath;
-      heading.textContent = projectPath.split('/').filter(Boolean).slice(-2).join('/');
+      heading.textContent = shortProjectPath(projectPath);
       terminalsEl.appendChild(heading);
     }
     wrapInGridCard(sid);

--- a/public/settings-panel.js
+++ b/public/settings-panel.js
@@ -31,7 +31,7 @@
     const globalSettings = isProject ? ((await window.api.getSetting('global')) || {}) : {};
 
     const shortName = isProject
-      ? projectPath.split('/').filter(Boolean).slice(-2).join('/')
+      ? shortProjectPath(projectPath)
       : 'Global';
 
     settingsViewerTitle.textContent = (isProject ? 'Project Settings — ' : 'Global Settings — ') + shortName;

--- a/public/sidebar.js
+++ b/public/sidebar.js
@@ -284,7 +284,7 @@ function renderProjects(projects, resort) {
     const header = document.createElement('div');
     header.className = 'project-header';
     header.id = 'ph-' + fId;
-    const shortName = project.projectPath.split('/').filter(Boolean).slice(-2).join('/');
+    const shortName = shortProjectPath(project.projectPath);
     header.innerHTML = `<span class="arrow">&#9660;</span> <span class="project-name">${shortName}</span>`;
 
     const scheduleBtn = document.createElement('button');
@@ -460,7 +460,7 @@ function rebindSidebarEvents(projects) {
         e.stopPropagation();
         const sessions = project.sessions.filter(s => !s.archived);
         if (sessions.length === 0) return;
-        const shortName = project.projectPath.split('/').filter(Boolean).slice(-2).join('/');
+        const shortName = shortProjectPath(project.projectPath);
         if (!confirm(`Archive all ${sessions.length} session${sessions.length > 1 ? 's' : ''} in ${shortName}?`)) return;
         for (const s of sessions) {
           if (activePtyIds.has(s.sessionId)) {

--- a/public/utils.js
+++ b/public/utils.js
@@ -1,5 +1,17 @@
 // --- Utility functions (shared across renderer modules) ---
 
+/**
+ * Shorten a project path for display: its last two segments.
+ *
+ * Splits on both separators. projectPath comes from a session's `cwd`, which on
+ * Windows is backslash-separated — splitting on '/' alone finds no separator, so
+ * every "short" label rendered the entire path.
+ */
+function shortProjectPath(projectPath) {
+  if (!projectPath) return '';
+  return projectPath.split(/[\\/]/).filter(Boolean).slice(-2).join('/');
+}
+
 // Mirror Claude CLI's project-folder naming. Must stay in sync with
 // encode-project-path.js (main process). Reverse-engineered from claude CLI 2.1.126.
 function encodeProjectPath(projectPath) {


### PR DESCRIPTION
## The bug

Every place that shortens a project path for display does:

```js
projectPath.split('/').filter(Boolean).slice(-2).join('/')
```

But `projectPath` comes from a session's `cwd`, which is **backslash**-separated on Windows. The split finds no separator, `slice(-2)` keeps the single element, and the label renders the entire path:

```
C:\Users\me\Documents\Vault\Projects\Early_App     (rendered)
Projects/Early_App                                  (intended)
```

So on Windows nothing is shortened anywhere — sidebar project headers, grid view headings and cards, the new-session dialog title, the settings viewer title, and the plans/memory list all show full absolute paths. In a narrow sidebar that means the meaningful part of the name is the part that gets truncated away.

## The fix

Adds `shortProjectPath()` to `public/utils.js` — same logic, splitting on `[\/]` — and routes the six renderer sites through it. `main.js` gets the same split locally, since it cannot share a renderer helper.

No behaviour change on macOS or Linux: forward slashes still split exactly as before.

## Verified

Ran the build on Windows against a real database. Sidebar labels before and after:

```
before   C:\Users\dbele\Documents\ObsidianVault\Wiki_Claude\Projects\Switchboard
after    Projects/Switchboard
         TikTok/Neon_Psycho
         Projects/Early_App
         ObsidianVault/Wiki_Claude
```
