### PR TITLE
ci: pin the Windows runner to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,13 @@ jobs:
         include:
           - os: macos-14
             platform: mac
-          - os: windows-latest
+          # Pinned, not `windows-latest`: that label has rolled over to Windows
+          # Server 2025, whose image no longer ships the Visual Studio C++
+          # toolchain node-gyp needs. On it, electron-builder's install-app-deps
+          # dies with "Could not find any Visual Studio installation to use"
+          # while rebuilding node-pty, so the Windows build never produces an
+          # artifact. 2022 still carries the toolchain.
+          - os: windows-2022
             platform: win
           # Linux is split per-arch to avoid electron-builder bundling native
           # modules from the wrong architecture. When multiple targets (AppImage


### PR DESCRIPTION
`windows-latest` has rolled over to Windows Server 2025, whose image no longer ships the Visual Studio C++ toolchain `node-gyp` needs. Every Windows build fails in electron-builder's `install-app-deps` while rebuilding `node-pty`:

```
Error: Could not find any Visual Studio installation to use
  ⨯ node-gyp failed to rebuild '...\node_modules\node-pty'  failedTask=installAppDeps
```

Observed on [run 30686024328](https://github.com/doctly/switchboard/actions/runs/30686024328/job/91331847743), triggered by a push to #55. macOS passed in the same run, so this is Windows-image-specific, not a code problem.

Pinning to `windows-2022` restores an image that still carries the toolchain.

### Why this went unnoticed

`build.yml` triggers only on `pull_request` and `v*` tags — never on push to `main` — and recent fork PRs are all parked at `action_required` pending maintainer approval. So no run had actually executed in a while, and the last green Windows runs predate the image rollover. Worth considering separately: adding `push: branches: [main]` so regressions surface on merge rather than on whichever PR happens to trigger a run.

### Credit

@Flaykz spotted this independently and included the same pin in #72. Pulling it out here so it lands on its own merits and #72 can stay focused on the status-bar gauges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)